### PR TITLE
Do not render trashed elements

### DIFF
--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -18,7 +18,10 @@ module Alchemy
       belongs_to :language
 
       has_many :elements
-      has_many :all_elements, record_type: :element, serializer: ElementSerializer
+
+      has_many :all_elements, record_type: :element, serializer: ElementSerializer do |page|
+        page.all_elements.select { |e| e.public? && !e.trashed? }
+      end
 
       with_options if: ->(_, params) { params[:admin] == true } do
         attribute :tag_list

--- a/spec/serializers/alchemy/json_api/page_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/page_serializer_spec.rb
@@ -54,13 +54,16 @@ RSpec.describe Alchemy::JsonApi::PageSerializer do
 
   describe "relationships" do
     let(:element) { FactoryBot.create(:alchemy_element) }
+    let(:trashed_element) { FactoryBot.create(:alchemy_element, :trashed) }
     subject { serializer.serializable_hash[:data][:relationships] }
 
     before do
-      page.elements << element
+      page.all_elements << element
+      page.all_elements << trashed_element
+      trashed_element.trash!
     end
 
-    it "has the right keys and values" do
+    it "has the right keys and values, and does not include trashed elements" do
       expect(subject[:elements]).to eq(data: [{ id: element.id.to_s, type: :element }])
       expect(subject[:all_elements]).to eq(data: [{ id: element.id.to_s, type: :element }])
       expect(subject[:language]).to eq(data: { id: page.language_id.to_s, type: :language })


### PR DESCRIPTION
Alchemy's `Alchemy::Page#all_elements` relation includes trashed
elements. Since this gem for now does not include authentication, we
only want to render out elements that are, actually, public.