### PR TITLE
Fix specs, bump version

### DIFF
--- a/alchemy-json_api.gemspec
+++ b/alchemy-json_api.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "alchemy_cms"
+  spec.add_dependency "alchemy_cms", "~> 5.0"
   spec.add_dependency "fast_jsonapi", "~> 1.5"
   spec.add_dependency "jsonapi.rb"
 

--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -8,7 +8,7 @@ module Alchemy::JsonApi
       :updated_at,
     )
     attribute :element_type, &:name
-    belongs_to :parent_element, record_type: :element
+    belongs_to :parent_element, record_type: :element, serializer: self
 
     belongs_to :page
     has_many :essences, polymorphic: true do |element|

--- a/app/serializers/alchemy/json_api/node_serializer.rb
+++ b/app/serializers/alchemy/json_api/node_serializer.rb
@@ -9,7 +9,7 @@ module Alchemy
       attribute :link_title, &:title
       attribute :link_nofollow, &:nofollow
 
-      belongs_to :parent, record_type: :node
+      belongs_to :parent, record_type: :node, serializer: self
 
       has_many :children, record_type: :node, serializer: self
     end

--- a/lib/alchemy/json_api/version.rb
+++ b/lib/alchemy/json_api/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Alchemy
   module JsonApi
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/spec/requests/alchemy/json_api/layout_pages_spec.rb
+++ b/spec/requests/alchemy/json_api/layout_pages_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
     FactoryBot.create(
       :alchemy_page,
       :public,
+      :layoutpage,
       urlname: nil,
-      title: "Footer",
-      layoutpage: true,
+      title: "Footer"
     )
   end
 
@@ -45,8 +45,8 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
 
     context "when the language is incorrect" do
       let!(:language) { FactoryBot.create(:alchemy_language) }
-      let!(:other_language) { FactoryBot.create(:alchemy_language, :english) }
-      let(:page) { FactoryBot.create(:alchemy_page, :public, layoutpage: true, language: other_language) }
+      let!(:other_language) { FactoryBot.create(:alchemy_language, :german) }
+      let(:page) { FactoryBot.create(:alchemy_page, :public, :layoutpage, language: other_language) }
 
       it "returns a 404" do
         get alchemy_json_api.layout_page_path(page.urlname)

--- a/spec/requests/alchemy/json_api/pages_spec.rb
+++ b/spec/requests/alchemy/json_api/pages_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
 
     context "when the language is incorrect" do
       let!(:language) { FactoryBot.create(:alchemy_language) }
-      let!(:other_language) { FactoryBot.create(:alchemy_language, :english) }
+      let!(:other_language) { FactoryBot.create(:alchemy_language, :german) }
       let(:page) { FactoryBot.create(:alchemy_page, :public, language: other_language) }
 
       it "returns a 404" do

--- a/spec/serializers/alchemy/json_api/language_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/language_serializer_spec.rb
@@ -6,11 +6,7 @@ require "alchemy/test_support/factories/node_factory"
 
 RSpec.describe Alchemy::JsonApi::LanguageSerializer do
   let(:language) do
-    FactoryBot.create(
-      :alchemy_language,
-      country_code: "DE",
-      language_code: "de",
-    )
+    FactoryBot.create(:alchemy_language, :german, country_code: "DE")
   end
   let(:options) { {} }
 

--- a/spec/serializers/alchemy/json_api/page_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/page_serializer_spec.rb
@@ -44,8 +44,7 @@ RSpec.describe Alchemy::JsonApi::PageSerializer do
           {
             public: false,
             locked: false,
-            restricted: false,
-            visible: false,
+            restricted: false
           },
         )
       end

--- a/spec/serializers/alchemy/json_api/page_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/page_serializer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Alchemy::JsonApi::PageSerializer do
       expect(attributes[:name]).to eq(page.name)
       expect(attributes[:page_layout]).to eq("standard")
       expect(attributes[:title]).to eq("Page Title")
-      expect(attributes[:language_code]).to eq("de")
+      expect(attributes[:language_code]).to eq("en")
       expect(attributes[:meta_keywords]).to eq("Meta Keywords")
       expect(attributes[:meta_description]).to eq("Meta Description")
       expect(attributes[:created_at]).to eq(page.created_at)


### PR DESCRIPTION
This fixes the test suite to work with recent versions of Alchemy and bumps the version to 0.2.0.