### PR TITLE
Add support for nested urlnames

### DIFF
--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -34,12 +34,11 @@ module Alchemy
       end
 
       def load_page_by_id
-        page_scope.find_by(id: params[:id])
+        page_scope.find_by(id: params[:path])
       end
 
       def load_page_by_urlname
-        # The route param is called :id although it might be a string
-        page_scope.find_by(urlname: params[:id])
+        page_scope.find_by(urlname: params[:path])
       end
 
       def page_scope

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 Alchemy::JsonApi::Engine.routes.draw do
-  resources :pages, only: [:show, :index]
-  resources :layout_pages, only: [:show, :index]
+  resources :pages, only: [:index]
+  get "pages/*path" => "pages#show", as: :page
+  resources :layout_pages, only: [:index]
+  get "layout_pages/*path" => "layout_pages#show", as: :layout_page
 end

--- a/spec/requests/alchemy/json_api/layout_pages_spec.rb
+++ b/spec/requests/alchemy/json_api/layout_pages_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 require "alchemy/test_support/factories/page_factory"
 require "alchemy/test_support/factories/element_factory"
 
-RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
+RSpec.describe "Alchemy::JsonApi::LayoutPagesController", type: :request do
   let(:page) do
     FactoryBot.create(
       :alchemy_page,
@@ -14,7 +14,7 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
     )
   end
 
-  describe "GET /alchemy/json_api/pages/:id" do
+  describe "GET /alchemy/json_api/layout_pages/:id" do
     it "gets a valid JSON:API document" do
       get alchemy_json_api.layout_page_path(page)
       expect(response).to have_http_status(200)
@@ -55,7 +55,7 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
     end
   end
 
-  describe "GET /alchemy/json_api/pages" do
+  describe "GET /alchemy/json_api/layout_pages" do
     context "with contentpages and unpublished layout pages" do
       let!(:layoutpage) { FactoryBot.create(:alchemy_page, :layoutpage, :public) }
       let!(:non_public_layout_page) { FactoryBot.create(:alchemy_page, :layoutpage) }

--- a/spec/requests/alchemy/json_api/pages_spec.rb
+++ b/spec/requests/alchemy/json_api/pages_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
       end
     end
 
+    context "when requesting a nested URL" do
+      let(:page) do
+        FactoryBot.create(
+          :alchemy_page,
+          :public,
+          urlname: "a-nested/page",
+        )
+      end
+
+      it "finds the page" do
+        get alchemy_json_api.page_path(page.urlname)
+        expect(response).to have_http_status(200)
+      end
+    end
+
     context "when the language is incorrect" do
       let!(:language) { FactoryBot.create(:alchemy_language) }
       let!(:other_language) { FactoryBot.create(:alchemy_language, :german) }

--- a/spec/routing/layout_page_routing_spec.rb
+++ b/spec/routing/layout_page_routing_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Page Routing" do
+  routes { Alchemy::JsonApi::Engine.routes }
+
+  it "routes layout_pages/" do
+    expect(get: "/layout_pages").to route_to(
+      controller: "alchemy/json_api/layout_pages",
+      action: "index",
+    )
+  end
+
+  it "routes layout_pages/:id" do
+    expect(get: "/layout_pages/1").to route_to(
+      controller: "alchemy/json_api/layout_pages",
+      action: "show",
+      path: "1",
+    )
+  end
+
+  it "routes layout_pages/:urlname" do
+    expect(get: "/layout_pages/a-page").to route_to(
+      controller: "alchemy/json_api/layout_pages",
+      action: "show",
+      path: "a-page",
+    )
+  end
+
+  it "routes layout_pages/:nested/urlname" do
+    expect(get: "/layout_pages/a-nested/page").to route_to(
+      controller: "alchemy/json_api/layout_pages",
+      action: "show",
+      path: "a-nested/page",
+    )
+  end
+end

--- a/spec/routing/page_routing_spec.rb
+++ b/spec/routing/page_routing_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Page Routing" do
+  routes { Alchemy::JsonApi::Engine.routes }
+
+  it "routes pages/" do
+    expect(get: "/pages").to route_to(
+      controller: "alchemy/json_api/pages",
+      action: "index",
+    )
+  end
+
+  it "routes pages/:id" do
+    expect(get: "/pages/1").to route_to(
+      controller: "alchemy/json_api/pages",
+      action: "show",
+      path: "1",
+    )
+  end
+
+  it "routes pages/:urlname" do
+    expect(get: "/pages/a-page").to route_to(
+      controller: "alchemy/json_api/pages",
+      action: "show",
+      path: "a-page",
+    )
+  end
+
+  it "routes pages/:nested/urlname" do
+    expect(get: "/pages/a-nested/page").to route_to(
+      controller: "alchemy/json_api/pages",
+      action: "show",
+      path: "a-nested/page",
+    )
+  end
+end


### PR DESCRIPTION
We are able to request nested urlnames now as well. Before we only support top level urlnames.