### PR TITLE
Use full module paths in serializers

### DIFF
--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -1,25 +1,27 @@
 # frozen_string_literal: true
-module Alchemy::JsonApi
-  class ElementSerializer
-    include FastJsonapi::ObjectSerializer
-    attributes(
-      :position,
-      :created_at,
-      :updated_at,
-    )
-    attribute :element_type, &:name
-    belongs_to :parent_element, record_type: :element, serializer: self
+module Alchemy
+  module JsonApi
+    class ElementSerializer
+      include FastJsonapi::ObjectSerializer
+      attributes(
+        :position,
+        :created_at,
+        :updated_at,
+      )
+      attribute :element_type, &:name
+      belongs_to :parent_element, record_type: :element, serializer: self
 
-    belongs_to :page
-    has_many :essences, polymorphic: true do |element|
-      element.contents.map(&:essence)
-    end
+      belongs_to :page
+      has_many :essences, polymorphic: true do |element|
+        element.contents.map(&:essence)
+      end
 
-    has_many :nested_elements, record_type: :element, serializer: self
+      has_many :nested_elements, record_type: :element, serializer: self
 
-    with_options if: ->(_, params) { params[:admin] == true } do
-      attribute :tag_list
-      attribute :display_name, &:display_name_with_preview_text
+      with_options if: ->(_, params) { params[:admin] == true } do
+        attribute :tag_list
+        attribute :display_name, &:display_name_with_preview_text
+      end
     end
   end
 end

--- a/app/serializers/alchemy/json_api/essence_boolean_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_boolean_serializer.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 require "alchemy/json_api/essence_serializer"
 
-module Alchemy::JsonApi
-  class EssenceBooleanSerializer
-    include EssenceSerializer
+module Alchemy
+  module JsonApi
+    class EssenceBooleanSerializer
+      include EssenceSerializer
+    end
   end
 end

--- a/app/serializers/alchemy/json_api/essence_date_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_date_serializer.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 require "alchemy/json_api/essence_serializer"
 
-module Alchemy::JsonApi
-  class EssenceDateSerializer
-    include EssenceSerializer
+module Alchemy
+  module JsonApi
+    class EssenceDateSerializer
+      include EssenceSerializer
+    end
   end
 end

--- a/app/serializers/alchemy/json_api/essence_file_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_file_serializer.rb
@@ -1,29 +1,31 @@
 # frozen_string_literal: true
 require "alchemy/json_api/essence_serializer"
 
-module Alchemy::JsonApi
-  class EssenceFileSerializer
-    include EssenceSerializer
+module Alchemy
+  module JsonApi
+    class EssenceFileSerializer
+      include EssenceSerializer
 
-    attribute :link_title, &:title
+      attribute :link_title, &:title
 
-    attribute :ingredient, &:attachment_url
+      attribute :ingredient, &:attachment_url
 
-    with_options if: proc { |essence| essence.attachment.present? } do
-      attribute :attachment_name do |essence|
-        essence.attachment.name
-      end
+      with_options if: proc { |essence| essence.attachment.present? } do
+        attribute :attachment_name do |essence|
+          essence.attachment.name
+        end
 
-      attribute :attachment_file_name do |essence|
-        essence.attachment.file_name
-      end
+        attribute :attachment_file_name do |essence|
+          essence.attachment.file_name
+        end
 
-      attribute :attachment_mime_type do |essence|
-        essence.attachment.file_mime_type
-      end
+        attribute :attachment_mime_type do |essence|
+          essence.attachment.file_mime_type
+        end
 
-      attribute :attachment_file_size do |essence|
-        essence.attachment.file_size
+        attribute :attachment_file_size do |essence|
+          essence.attachment.file_size
+        end
       end
     end
   end

--- a/app/serializers/alchemy/json_api/essence_html_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_html_serializer.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 require "alchemy/json_api/essence_serializer"
 
-module Alchemy::JsonApi
-  class EssenceHtmlSerializer
-    include EssenceSerializer
+module Alchemy
+  module JsonApi
+    class EssenceHtmlSerializer
+      include EssenceSerializer
+    end
   end
 end

--- a/app/serializers/alchemy/json_api/essence_link_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_link_serializer.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 require "alchemy/json_api/essence_serializer"
 
-module Alchemy::JsonApi
-  class EssenceLinkSerializer
-    include EssenceSerializer
-    attributes(
-      :link_title,
-      :link_target,
-    )
+module Alchemy
+  module JsonApi
+    class EssenceLinkSerializer
+      include EssenceSerializer
+      attributes(
+        :link_title,
+        :link_target,
+      )
+    end
   end
 end

--- a/app/serializers/alchemy/json_api/essence_node_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_node_serializer.rb
@@ -1,31 +1,33 @@
 # frozen_string_literal: true
 require "alchemy/json_api/essence_serializer"
 
-module Alchemy::JsonApi
-  class EssenceNodeSerializer
-    include EssenceSerializer
+module Alchemy
+  module JsonApi
+    class EssenceNodeSerializer
+      include EssenceSerializer
 
-    attribute :ingredient do |essence|
-      essence&.node&.name
-    end
-
-    belongs_to :node
-
-    with_options if: proc { |essence| essence.node.present? } do
-      attribute :name do |essence|
-        essence.node.name
+      attribute :ingredient do |essence|
+        essence&.node&.name
       end
 
-      attribute :link_url do |essence|
-        essence.node.url
-      end
+      belongs_to :node
 
-      attribute :link_title do |essence|
-        essence.node.title
-      end
+      with_options if: proc { |essence| essence.node.present? } do
+        attribute :name do |essence|
+          essence.node.name
+        end
 
-      attribute :link_nofollow do |essence|
-        essence.node.nofollow
+        attribute :link_url do |essence|
+          essence.node.url
+        end
+
+        attribute :link_title do |essence|
+          essence.node.title
+        end
+
+        attribute :link_nofollow do |essence|
+          essence.node.nofollow
+        end
       end
     end
   end

--- a/app/serializers/alchemy/json_api/essence_page_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_page_serializer.rb
@@ -1,22 +1,24 @@
 # frozen_string_literal: true
 require "alchemy/json_api/essence_serializer"
 
-module Alchemy::JsonApi
-  class EssencePageSerializer
-    include EssenceSerializer
+module Alchemy
+  module JsonApi
+    class EssencePageSerializer
+      include EssenceSerializer
 
-    attribute :ingredient do |essence|
-      essence.page&.url_path
+      attribute :ingredient do |essence|
+        essence.page&.url_path
+      end
+
+      attribute :page_name do |essence|
+        essence.page&.name
+      end
+
+      attribute :page_url do |essence|
+        essence.page&.url_path
+      end
+
+      has_one :page, record_type: :page, serializer: PageSerializer
     end
-
-    attribute :page_name do |essence|
-      essence.page&.name
-    end
-
-    attribute :page_url do |essence|
-      essence.page&.url_path
-    end
-
-    has_one :page, record_type: :page, serializer: PageSerializer
   end
 end

--- a/app/serializers/alchemy/json_api/essence_picture_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_picture_serializer.rb
@@ -1,39 +1,41 @@
 # frozen_string_literal: true
 require "alchemy/json_api/essence_serializer"
 
-module Alchemy::JsonApi
-  class EssencePictureSerializer
-    include EssenceSerializer
+module Alchemy
+  module JsonApi
+    class EssencePictureSerializer
+      include EssenceSerializer
 
-    attributes(
-      :title,
-      :caption,
-      :link_title,
-      :link_target,
-    )
-    attribute :ingredient, &:picture_url
-    attribute :alt_text, &:alt_tag
-    attribute :link_url, &:link
+      attributes(
+        :title,
+        :caption,
+        :link_title,
+        :link_target,
+      )
+      attribute :ingredient, &:picture_url
+      attribute :alt_text, &:alt_tag
+      attribute :link_url, &:link
 
-    with_options if: proc { |essence| essence.picture.present? } do
-      attribute :image_dimensions do |essence|
-        essence.sizes_from_string(essence.render_size)
-      end
+      with_options if: proc { |essence| essence.picture.present? } do
+        attribute :image_dimensions do |essence|
+          essence.sizes_from_string(essence.render_size)
+        end
 
-      attribute :image_name do |essence|
-        essence.picture.name
-      end
+        attribute :image_name do |essence|
+          essence.picture.name
+        end
 
-      attribute :image_file_name do |essence|
-        essence.picture.image_file_name
-      end
+        attribute :image_file_name do |essence|
+          essence.picture.image_file_name
+        end
 
-      attribute :image_mime_type do |essence|
-        "image/#{essence.picture.image_file_format}"
-      end
+        attribute :image_mime_type do |essence|
+          "image/#{essence.picture.image_file_format}"
+        end
 
-      attribute :image_file_size do |essence|
-        essence.picture.image_file_size
+        attribute :image_file_size do |essence|
+          essence.picture.image_file_size
+        end
       end
     end
   end

--- a/app/serializers/alchemy/json_api/essence_richtext_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_richtext_serializer.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 require "alchemy/json_api/essence_serializer"
 
-module Alchemy::JsonApi
-  class EssenceRichtextSerializer
-    include EssenceSerializer
-    attributes(
-      :body,
-      :stripped_body,
-    )
+module Alchemy
+  module JsonApi
+    class EssenceRichtextSerializer
+      include EssenceSerializer
+      attributes(
+        :body,
+        :stripped_body,
+      )
+    end
   end
 end

--- a/app/serializers/alchemy/json_api/essence_select_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_select_serializer.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 require "alchemy/json_api/essence_serializer"
 
-module Alchemy::JsonApi
-  class EssenceSelectSerializer
-    include EssenceSerializer
+module Alchemy
+  module JsonApi
+    class EssenceSelectSerializer
+      include EssenceSerializer
+    end
   end
 end

--- a/app/serializers/alchemy/json_api/essence_text_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_text_serializer.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 require "alchemy/json_api/essence_serializer"
 
-module Alchemy::JsonApi
-  class EssenceTextSerializer
-    include EssenceSerializer
-    attributes(
-      :body,
-      :link_title,
-      :link_target,
-    )
-    attribute :link_url, &:link
+module Alchemy
+  module JsonApi
+    class EssenceTextSerializer
+      include EssenceSerializer
+      attributes(
+        :body,
+        :link_title,
+        :link_target,
+      )
+      attribute :link_url, &:link
+    end
   end
 end


### PR DESCRIPTION
Ruby is very picky with constants and Rails auto loading is doing the rest. So we need to make sure to not intropuce two constants in this Gem.