### PR TITLE
Rename element_type into name

### DIFF
--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -4,11 +4,11 @@ module Alchemy
     class ElementSerializer
       include FastJsonapi::ObjectSerializer
       attributes(
+        :name,
         :position,
         :created_at,
         :updated_at,
       )
-      attribute :element_type, &:name
       belongs_to :parent_element, record_type: :element, serializer: self
 
       belongs_to :page

--- a/spec/serializers/alchemy/json_api/element_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/element_serializer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Alchemy::JsonApi::ElementSerializer do
     subject { serializer.serializable_hash[:data][:attributes] }
 
     it "has the right keys and values" do
-      expect(subject[:element_type]).to eq("article")
+      expect(subject[:name]).to eq("article")
       expect(subject[:created_at]).to eq(element.created_at)
       expect(subject[:updated_at]).to eq(element.updated_at)
       expect(subject[:position]).to eq(element.position)


### PR DESCRIPTION
This is the name of the attribute in Alchemy core, so we should use that name as well.