### PR TITLE
Specify Record Type and Serializer Class for all relations

### DIFF
--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -12,7 +12,8 @@ module Alchemy
       )
       belongs_to :parent_element, record_type: :element, serializer: self
 
-      belongs_to :page
+      belongs_to :page, record_type: :page, serializer: PageSerializer
+
       has_many :essences, polymorphic: true do |element|
         element.contents.map(&:essence)
       end

--- a/app/serializers/alchemy/json_api/essence_node_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_node_serializer.rb
@@ -10,7 +10,7 @@ module Alchemy
         essence&.node&.name
       end
 
-      belongs_to :node
+      belongs_to :node, record_type: :node, serializer: NodeSerializer
 
       with_options if: proc { |essence| essence.node.present? } do
         attribute :name do |essence|

--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -15,9 +15,9 @@ module Alchemy
         :updated_at,
       )
 
-      belongs_to :language
+      belongs_to :language, record_type: :language, serializer: LanguageSerializer
 
-      has_many :elements
+      has_many :elements, record_type: :element, serializer: ElementSerializer
       has_many :fixed_elements, record_type: :element, serializer: ElementSerializer
 
       has_many :all_elements, record_type: :element, serializer: ElementSerializer do |page|


### PR DESCRIPTION
If we don't do this, we run into a bug in production where this gem will
try to load Alchemy's internal serializers (`Alchemy::NodeSerializer`
and friends).