### PR TITLE
Fully qualify the names of Serializer classes

### DIFF
--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -12,7 +12,7 @@ module Alchemy
       )
       belongs_to :parent_element, record_type: :element, serializer: self
 
-      belongs_to :page, record_type: :page, serializer: PageSerializer
+      belongs_to :page, record_type: :page, serializer: ::Alchemy::JsonApi::PageSerializer
 
       has_many :essences, polymorphic: true do |element|
         element.contents.map(&:essence)

--- a/app/serializers/alchemy/json_api/essence_node_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_node_serializer.rb
@@ -10,7 +10,7 @@ module Alchemy
         essence&.node&.name
       end
 
-      belongs_to :node, record_type: :node, serializer: NodeSerializer
+      belongs_to :node, record_type: :node, serializer: ::Alchemy::JsonApi::NodeSerializer
 
       with_options if: proc { |essence| essence.node.present? } do
         attribute :name do |essence|

--- a/app/serializers/alchemy/json_api/essence_page_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_page_serializer.rb
@@ -18,7 +18,7 @@ module Alchemy
         essence.page&.url_path
       end
 
-      has_one :page, record_type: :page, serializer: PageSerializer
+      has_one :page, record_type: :page, serializer: ::Alchemy::JsonApi::PageSerializer
     end
   end
 end

--- a/app/serializers/alchemy/json_api/language_serializer.rb
+++ b/app/serializers/alchemy/json_api/language_serializer.rb
@@ -10,13 +10,13 @@ module Alchemy
         :locale,
       )
 
-      has_many :menu_items, record_type: :node, serializer: NodeSerializer, object_method_name: :nodes, id_method_name: :node_ids
+      has_many :menu_items, record_type: :node, serializer: ::Alchemy::JsonApi::NodeSerializer, object_method_name: :nodes, id_method_name: :node_ids
 
-      has_many :menus, record_type: :node, serializer: NodeSerializer do |language|
+      has_many :menus, record_type: :node, serializer: ::Alchemy::JsonApi::NodeSerializer do |language|
         language.nodes.select { |n| n.parent.nil? }
       end
       has_many :pages
-      has_one :root_page, record_type: :page, serializer: PageSerializer
+      has_one :root_page, record_type: :page, serializer: ::Alchemy::JsonApi::PageSerializer
 
       with_options if: ->(_, params) { params[:admin] == true } do
         attribute :created_at

--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -15,12 +15,12 @@ module Alchemy
         :updated_at,
       )
 
-      belongs_to :language, record_type: :language, serializer: LanguageSerializer
+      belongs_to :language, record_type: :language, serializer: ::Alchemy::JsonApi::LanguageSerializer
 
-      has_many :elements, record_type: :element, serializer: ElementSerializer
-      has_many :fixed_elements, record_type: :element, serializer: ElementSerializer
+      has_many :elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer
+      has_many :fixed_elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer
 
-      has_many :all_elements, record_type: :element, serializer: ElementSerializer do |page|
+      has_many :all_elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer do |page|
         page.all_elements.select { |e| e.public? && !e.trashed? }
       end
 

--- a/lib/alchemy/json_api/essence_serializer.rb
+++ b/lib/alchemy/json_api/essence_serializer.rb
@@ -4,7 +4,7 @@ module Alchemy
     module EssenceSerializer
       def self.included(klass)
         klass.include FastJsonapi::ObjectSerializer
-        klass.has_one :element, record_type: :element, serializer: ElementSerializer do |essence|
+        klass.has_one :element, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer do |essence|
           essence.content.element
         end
         klass.attributes :ingredient


### PR DESCRIPTION
There are naming conflicts with core Alchemy serializers that need to be
resolved cleanly. This does that.