### PR TITLE
Fix page base scope for anonymous users

### DIFF
--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -50,7 +50,7 @@ module Alchemy
         if can?(:edit_content, Page)
           pages = Page.all
         else
-          pages = Page.accessible_by(current_ability, :index)
+          pages = Page.published
         end
         pages.
           with_language(Language.current).


### PR DESCRIPTION
CanCanCan is not able to merge the `accessible_by` scope with other scopes.