### PR TITLE
Switch from fast_jsonapi to jsonapi-serializer

### DIFF
--- a/alchemy-json_api.gemspec
+++ b/alchemy-json_api.gemspec
@@ -18,8 +18,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "alchemy_cms", "~> 5.0"
-  spec.add_dependency "fast_jsonapi", "~> 1.5"
-  spec.add_dependency "jsonapi.rb"
+  spec.add_dependency "jsonapi.rb", "~> 1.6"
 
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "github_changelog_generator"

--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -2,7 +2,8 @@
 module Alchemy
   module JsonApi
     class ElementSerializer
-      include FastJsonapi::ObjectSerializer
+      include JSONAPI::Serializer
+
       attributes(
         :name,
         :fixed,

--- a/app/serializers/alchemy/json_api/language_serializer.rb
+++ b/app/serializers/alchemy/json_api/language_serializer.rb
@@ -2,7 +2,8 @@
 module Alchemy
   module JsonApi
     class LanguageSerializer
-      include FastJsonapi::ObjectSerializer
+      include JSONAPI::Serializer
+
       attributes(
         :name,
         :language_code,

--- a/app/serializers/alchemy/json_api/node_serializer.rb
+++ b/app/serializers/alchemy/json_api/node_serializer.rb
@@ -2,7 +2,7 @@
 module Alchemy
   module JsonApi
     class NodeSerializer
-      include FastJsonapi::ObjectSerializer
+      include JSONAPI::Serializer
 
       attributes :name
       attribute :link_url, &:url

--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -2,7 +2,8 @@
 module Alchemy
   module JsonApi
     class PageSerializer
-      include FastJsonapi::ObjectSerializer
+      include JSONAPI::Serializer
+
       attributes(
         :name,
         :urlname,

--- a/lib/alchemy/json_api/essence_serializer.rb
+++ b/lib/alchemy/json_api/essence_serializer.rb
@@ -3,7 +3,7 @@ module Alchemy
   module JsonApi
     module EssenceSerializer
       def self.included(klass)
-        klass.include FastJsonapi::ObjectSerializer
+        klass.include JSONAPI::Serializer
         klass.has_one :element, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer do |essence|
           essence.content.element
         end


### PR DESCRIPTION
Use the maintained fork of the [unmaintained](https://github.com/Netflix/fast_jsonapi#fast-json-api--warning-this-project-is-no-longer-maintained-warning) `fast_jsonapi` gem.

This is breaking of you have custom serializers that use the `FastJsonApi::ObjectSerializer`.

Closes #22 