### PR TITLE
Return all layoutpages regardless of publication status

### DIFF
--- a/app/controllers/alchemy/json_api/layout_pages_controller.rb
+++ b/app/controllers/alchemy/json_api/layout_pages_controller.rb
@@ -4,6 +4,10 @@ module Alchemy
     class LayoutPagesController < JsonApi::PagesController
       private
 
+      def base_page_scope
+        Page.all
+      end
+
       def page_scope
         page_scope_with_includes.layoutpages
       end

--- a/app/controllers/alchemy/json_api/layout_pages_controller.rb
+++ b/app/controllers/alchemy/json_api/layout_pages_controller.rb
@@ -5,7 +5,7 @@ module Alchemy
       private
 
       def page_scope
-        base_page_scope.layoutpages
+        page_scope_with_includes.layoutpages
       end
     end
   end

--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -42,19 +42,22 @@ module Alchemy
       end
 
       def page_scope
-        base_page_scope.contentpages
+        page_scope_with_includes.contentpages
+      end
+
+      def page_scope_with_includes
+        base_page_scope.
+          with_language(Language.current).
+          preload(language: {nodes: [:parent, :page]}, all_elements: [:parent_element, :nested_elements, { contents: { essence: :ingredient_association } }])
       end
 
       def base_page_scope
         # cancancan is not able to merge our complex AR scopes for logged in users
         if can?(:edit_content, Page)
-          pages = Page.all
+          Page.all
         else
-          pages = Page.published
+          Page.published
         end
-        pages.
-          with_language(Language.current).
-          preload(language: {nodes: [:parent, :page]}, all_elements: [:parent_element, :nested_elements, { contents: { essence: :ingredient_association } }])
       end
 
       def jsonapi_serializer_class(_resource, _is_collection)

--- a/spec/dummy/config/initializers/devise.rb
+++ b/spec/dummy/config/initializers/devise.rb
@@ -8,7 +8,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '0efe979fd17447a5b8f47c5f49ba3f0e8ede4b1c430f8b4000bd3ac022a5bd5f74e02d590053cf3ec0e44ed0485abf2f67beef23fed454d511dc35663cae6cac'
+  # config.secret_key = '30e6f7b47e95e4cc199b75b58fe4300feeaf80bad3386038bd42006b51f0a4ab9ea12cb9da037a53b5775c343953e9cc525b200aa52e9a37e51d30a7f9d69f60'
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
@@ -114,7 +114,7 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 11
 
   # Set up a pepper to generate the hashed password.
-  # config.pepper = '511f97a2a66a7be109618f51dab4cc72cd0562ef2f8aa1185e283e62367afb868a4947d3da2f77bfaf2a82c4d5c45cb14786d86fb1860b07347b4be2efafa35f'
+  # config.pepper = 'c580d48d74d68b91cf002b886713a6a5d2e5a0e6b500b5b7ddc9a73ec7d093a9c153a7393f22a59d7bb48aaedd29d6029e3f444702edc926c7f7b3160d1cc907'
 
   # Send a notification to the original email when the user's email is changed.
   # config.send_email_changed_notification = false

--- a/spec/requests/alchemy/json_api/layout_pages_spec.rb
+++ b/spec/requests/alchemy/json_api/layout_pages_spec.rb
@@ -58,24 +58,9 @@ RSpec.describe "Alchemy::JsonApi::LayoutPagesController", type: :request do
     context "when requesting an unpublished layout page" do
       let(:page) { FactoryBot.create(:alchemy_page, :layoutpage) }
 
-      context "as anonymous user" do
-        it "returns a 404" do
-          get alchemy_json_api.layout_page_path(page.urlname)
-          expect(response).to have_http_status(404)
-        end
-      end
-
-      context "as admin" do
-        before do
-          allow_any_instance_of(ApplicationController).to receive(:current_user) do
-            FactoryBot.create(:alchemy_admin_user)
-          end
-        end
-
-        it "finds the page" do
-          get alchemy_json_api.layout_page_path(page.urlname)
-          expect(response).to have_http_status(200)
-        end
+      it "finds the page" do
+        get alchemy_json_api.layout_page_path(page.urlname)
+        expect(response).to have_http_status(200)
       end
     end
   end
@@ -86,30 +71,12 @@ RSpec.describe "Alchemy::JsonApi::LayoutPagesController", type: :request do
       let!(:non_public_layout_page) { FactoryBot.create(:alchemy_page, :layoutpage) }
       let!(:public_page) { FactoryBot.create(:alchemy_page, :public) }
 
-      context "as anonymous user" do
-        it "returns only public layout pages" do
-          get alchemy_json_api.layout_pages_path
-          document = JSON.parse(response.body)
-          expect(document["data"]).to include(have_id(layoutpage.id.to_s))
-          expect(document["data"]).not_to include(have_id(non_public_layout_page.id.to_s))
-          expect(document["data"]).not_to include(have_id(public_page.id.to_s))
-        end
-      end
-
-      context "as admin user" do
-        before do
-          allow_any_instance_of(ApplicationController).to receive(:current_user) do
-            FactoryBot.create(:alchemy_admin_user)
-          end
-        end
-
-        it "returns all layout pages" do
-          get alchemy_json_api.layout_pages_path
-          document = JSON.parse(response.body)
-          expect(document["data"]).to include(have_id(layoutpage.id.to_s))
-          expect(document["data"]).to include(have_id(non_public_layout_page.id.to_s))
-          expect(document["data"]).not_to include(have_id(public_page.id.to_s))
-        end
+      it "returns all layout pages" do
+        get alchemy_json_api.layout_pages_path
+        document = JSON.parse(response.body)
+        expect(document["data"]).to include(have_id(layoutpage.id.to_s))
+        expect(document["data"]).to include(have_id(non_public_layout_page.id.to_s))
+        expect(document["data"]).not_to include(have_id(public_page.id.to_s))
       end
     end
 


### PR DESCRIPTION
Layoutpages do not have publication dates since they are not routable and are always displayed in the context of another page.