### PR TITLE
Do not include deprecated elements and essences

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ gemspec
 # gem 'byebug', group: [:development, :test]
 gem "sqlite3"
 
-gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: "master"
-gem "alchemy-devise", github: "AlchemyCMS/alchemy-devise", branch: "master"
+gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: "main"
+gem "alchemy-devise", github: "AlchemyCMS/alchemy-devise", branch: "main"
 gem "rufo"
 gem "rubocop"
 gem "pry-byebug"

--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -16,7 +16,7 @@ module Alchemy
       belongs_to :page, record_type: :page, serializer: ::Alchemy::JsonApi::PageSerializer
 
       has_many :essences, polymorphic: true do |element|
-        element.contents.map(&:essence)
+        element.contents.reject { |c| !!c.try(:deprecated?) }.map!(&:essence)
       end
 
       has_many :nested_elements, record_type: :element, serializer: self

--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -22,7 +22,7 @@ module Alchemy
       has_many :fixed_elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer
 
       has_many :all_elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer do |page|
-        page.all_elements.select { |e| e.public? && !e.trashed? }
+        page.all_elements.select { |e| e.public? && !e.trashed? && !e.try(:deprecated?) }
       end
 
       with_options if: ->(_, params) { params[:admin] == true } do

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -107,6 +107,7 @@
     - name: essence_html
       type: EssenceHtml
       hint: true
+      deprecated: true
     - name: essence_link
       type: EssenceLink
       hint: true
@@ -160,3 +161,6 @@
   fixed: true
   unique: true
   nestable_elements: [text]
+
+- name: old
+  deprecated: true

--- a/spec/requests/alchemy/json_api/pages_spec.rb
+++ b/spec/requests/alchemy/json_api/pages_spec.rb
@@ -29,11 +29,34 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
     context "when including elements and essences" do
       let(:page) { FactoryBot.create(:alchemy_page, :public, elements: [element]) }
       let(:element) { FactoryBot.create(:alchemy_element, name: "article", autogenerate_contents: true) }
+      let(:included) { JSON.parse(response.body)["included"] }
 
       it "includes the data" do
         get alchemy_json_api.page_path(page, include: "all_elements.essences")
-        included = JSON.parse(response.body)["included"]
         expect(included).to include(have_type("element").and(have_id(element.id.to_s)))
+        expect(included.length).to eq(5)
+      end
+
+      context "if deprecated elements are present" do
+        let!(:deprecated_element) do
+          FactoryBot.create(:alchemy_element, page: page, name: "old", autogenerate_contents: true)
+        end
+
+        it "returns only public elements" do
+          get alchemy_json_api.page_path(page, include: "all_elements.essences")
+          expect(included.length).to eq(5)
+        end
+      end
+
+      context "if deprecated contents in public elements are present" do
+        let!(:deprecated_element) do
+          FactoryBot.create(:alchemy_element, page: page, name: "all_you_can_eat", autogenerate_contents: true)
+        end
+
+        it "returns only public essences" do
+          get alchemy_json_api.page_path(page, include: "all_elements.essences")
+          expect(included.length).to eq(14)
+        end
       end
     end
 


### PR DESCRIPTION
Like with non-public and trashed elements we do not want to include deprecated elements (a new feature in Alchemy 5.2) with the public API responses.