### PR TITLE
Remove deprecated elements from all element relations

### DIFF
--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -19,7 +19,9 @@ module Alchemy
         element.contents.reject { |c| !!c.try(:deprecated?) }.map!(&:essence)
       end
 
-      has_many :nested_elements, record_type: :element, serializer: self
+      has_many :nested_elements, record_type: :element, serializer: self do |element|
+        element.nested_elements.reject { |c| !!c.try(:deprecated?) }
+      end
 
       with_options if: ->(_, params) { params[:admin] == true } do
         attribute :tag_list

--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -18,8 +18,13 @@ module Alchemy
 
       belongs_to :language, record_type: :language, serializer: ::Alchemy::JsonApi::LanguageSerializer
 
-      has_many :elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer
-      has_many :fixed_elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer
+      has_many :elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer do |page|
+        page.elements.reject { |e| !!e.try(:deprecated?) }
+      end
+
+      has_many :fixed_elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer do |page|
+        page.fixed_elements.reject { |c| !!c.try(:deprecated?) }
+      end
 
       has_many :all_elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer do |page|
         page.all_elements.select { |e| e.public? && !e.trashed? && !e.try(:deprecated?) }

--- a/spec/serializers/alchemy/json_api/element_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/element_serializer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "rails_helper"
 require "alchemy/test_support/factories"
+require "alchemy/version"
 
 RSpec.describe Alchemy::JsonApi::ElementSerializer do
   let(:element) do
@@ -8,12 +9,13 @@ RSpec.describe Alchemy::JsonApi::ElementSerializer do
       :alchemy_element,
       autogenerate_contents: true,
       tag_list: "Tag1,Tag2",
-      nested_elements: [nested_element],
+      nested_elements: [nested_element, deprecated_element],
       parent_element: parent_element,
     )
   end
   let(:nested_element) { FactoryBot.create(:alchemy_element) }
   let(:parent_element) { FactoryBot.create(:alchemy_element) }
+  let(:deprecated_element) { FactoryBot.create(:alchemy_element, name: "old") }
   let(:options) { {} }
 
   subject(:serializer) { described_class.new(element, options) }
@@ -46,7 +48,16 @@ RSpec.describe Alchemy::JsonApi::ElementSerializer do
     it "has the right keys and values" do
       expect(subject[:page]).to eq(data: { id: element.page_id.to_s, type: :page })
       expect(subject[:essences]).to eq(data: element.contents.map { |c| { id: c.essence_id.to_s, type: c.essence.class.name.demodulize.underscore.to_sym } })
-      expect(subject[:nested_elements]).to eq(data: [{ id: nested_element.id.to_s, type: :element }])
+      if Alchemy.gem_version >= Gem::Version.new("5.2.0.alpha")
+        expect(subject[:nested_elements]).to eq(data: [{ id: nested_element.id.to_s, type: :element }])
+      else
+        expect(subject[:nested_elements]).to eq(
+          data: [
+            { id: nested_element.id.to_s, type: :element },
+            { id: deprecated_element.id.to_s, type: :element },
+          ],
+        )
+      end
       expect(subject[:parent_element]).to eq(data: { id: parent_element.id.to_s, type: :element })
     end
   end


### PR DESCRIPTION
We need to remove the deprecated elements from all relations since
they are not included in the all_elements relation anymore.