### PR TITLE
Revert removal of deprecated elements

### DIFF
--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -16,7 +16,7 @@ module Alchemy
       belongs_to :page, record_type: :page, serializer: ::Alchemy::JsonApi::PageSerializer
 
       has_many :essences, polymorphic: true do |element|
-        element.contents.reject { |c| !!c.try(:deprecated?) }.map!(&:essence)
+        element.contents.map(&:essence)
       end
 
       has_many :nested_elements, record_type: :element, serializer: self

--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -19,9 +19,7 @@ module Alchemy
         element.contents.reject { |c| !!c.try(:deprecated?) }.map!(&:essence)
       end
 
-      has_many :nested_elements, record_type: :element, serializer: self do |element|
-        element.nested_elements.reject { |c| !!c.try(:deprecated?) }
-      end
+      has_many :nested_elements, record_type: :element, serializer: self
 
       with_options if: ->(_, params) { params[:admin] == true } do
         attribute :tag_list

--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -22,7 +22,7 @@ module Alchemy
       has_many :fixed_elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer
 
       has_many :all_elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer do |page|
-        page.all_elements.select { |e| e.public? && !e.trashed? && !e.try(:deprecated?) }
+        page.all_elements.select { |e| e.public? && !e.trashed? }
       end
 
       with_options if: ->(_, params) { params[:admin] == true } do

--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -18,13 +18,8 @@ module Alchemy
 
       belongs_to :language, record_type: :language, serializer: ::Alchemy::JsonApi::LanguageSerializer
 
-      has_many :elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer do |page|
-        page.elements.reject { |e| !!e.try(:deprecated?) }
-      end
-
-      has_many :fixed_elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer do |page|
-        page.fixed_elements.reject { |c| !!c.try(:deprecated?) }
-      end
+      has_many :elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer
+      has_many :fixed_elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer
 
       has_many :all_elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer do |page|
         page.all_elements.select { |e| e.public? && !e.trashed? && !e.try(:deprecated?) }

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -107,7 +107,6 @@
     - name: essence_html
       type: EssenceHtml
       hint: true
-      deprecated: true
     - name: essence_link
       type: EssenceLink
       hint: true
@@ -161,6 +160,3 @@
   fixed: true
   unique: true
   nestable_elements: [text]
-
-- name: old
-  deprecated: true

--- a/spec/requests/alchemy/json_api/pages_spec.rb
+++ b/spec/requests/alchemy/json_api/pages_spec.rb
@@ -30,34 +30,11 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
     context "when including elements and essences" do
       let(:page) { FactoryBot.create(:alchemy_page, :public, elements: [element]) }
       let(:element) { FactoryBot.create(:alchemy_element, name: "article", autogenerate_contents: true) }
-      let(:included) { JSON.parse(response.body)["included"] }
 
       it "includes the data" do
         get alchemy_json_api.page_path(page, include: "all_elements.essences")
+        included = JSON.parse(response.body)["included"]
         expect(included).to include(have_type("element").and(have_id(element.id.to_s)))
-        expect(included.length).to eq(5)
-      end
-
-      context "if deprecated elements are present" do
-        let!(:deprecated_element) do
-          FactoryBot.create(:alchemy_element, page: page, name: "old", autogenerate_contents: true)
-        end
-
-        it "returns only public elements" do
-          get alchemy_json_api.page_path(page, include: "all_elements.essences")
-          expect(included.length).to eq(Alchemy.gem_version >= Gem::Version.new("5.2.0.alpha") ? 5 : 6)
-        end
-      end
-
-      context "if deprecated contents in public elements are present" do
-        let!(:deprecated_element) do
-          FactoryBot.create(:alchemy_element, page: page, name: "all_you_can_eat", autogenerate_contents: true)
-        end
-
-        it "returns only public essences" do
-          get alchemy_json_api.page_path(page, include: "all_elements.essences")
-          expect(included.length).to eq(Alchemy.gem_version >= Gem::Version.new("5.2.0.alpha") ? 14 : 15)
-        end
       end
     end
 

--- a/spec/serializers/alchemy/json_api/element_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/element_serializer_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require "rails_helper"
 require "alchemy/test_support/factories"
-require "alchemy/version"
 
 RSpec.describe Alchemy::JsonApi::ElementSerializer do
   let(:element) do
@@ -9,13 +8,12 @@ RSpec.describe Alchemy::JsonApi::ElementSerializer do
       :alchemy_element,
       autogenerate_contents: true,
       tag_list: "Tag1,Tag2",
-      nested_elements: [nested_element, deprecated_element],
+      nested_elements: [nested_element],
       parent_element: parent_element,
     )
   end
   let(:nested_element) { FactoryBot.create(:alchemy_element) }
   let(:parent_element) { FactoryBot.create(:alchemy_element) }
-  let(:deprecated_element) { FactoryBot.create(:alchemy_element, name: "old") }
   let(:options) { {} }
 
   subject(:serializer) { described_class.new(element, options) }
@@ -48,16 +46,7 @@ RSpec.describe Alchemy::JsonApi::ElementSerializer do
     it "has the right keys and values" do
       expect(subject[:page]).to eq(data: { id: element.page_id.to_s, type: :page })
       expect(subject[:essences]).to eq(data: element.contents.map { |c| { id: c.essence_id.to_s, type: c.essence.class.name.demodulize.underscore.to_sym } })
-      if Alchemy.gem_version >= Gem::Version.new("5.2.0.alpha")
-        expect(subject[:nested_elements]).to eq(data: [{ id: nested_element.id.to_s, type: :element }])
-      else
-        expect(subject[:nested_elements]).to eq(
-          data: [
-            { id: nested_element.id.to_s, type: :element },
-            { id: deprecated_element.id.to_s, type: :element },
-          ],
-        )
-      end
+      expect(subject[:nested_elements]).to eq(data: [{ id: nested_element.id.to_s, type: :element }])
       expect(subject[:parent_element]).to eq(data: { id: parent_element.id.to_s, type: :element })
     end
   end

--- a/spec/serializers/alchemy/json_api/page_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/page_serializer_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require "rails_helper"
 require "alchemy/test_support/factories"
-require "alchemy/version"
 
 RSpec.describe Alchemy::JsonApi::PageSerializer do
   let(:page) do
@@ -56,38 +55,19 @@ RSpec.describe Alchemy::JsonApi::PageSerializer do
     let(:element) { FactoryBot.create(:alchemy_element) }
     let(:fixed_element) { FactoryBot.create(:alchemy_element, fixed: true) }
     let(:trashed_element) { FactoryBot.create(:alchemy_element, :trashed) }
-    let(:deprecated_element) { FactoryBot.create(:alchemy_element, name: "old") }
-
     subject { serializer.serializable_hash[:data][:relationships] }
 
     before do
       page.all_elements << element
       page.all_elements << fixed_element
       page.all_elements << trashed_element
-      page.all_elements << deprecated_element
       trashed_element.trash!
     end
 
-    it "has the right keys and values, and does not include trashed, hidden or deprecated elements" do
-      if Alchemy.gem_version >= Gem::Version.new("5.2.0.alpha")
-        expect(subject[:elements]).to eq(data: [{ id: element.id.to_s, type: :element }])
-        expect(subject[:all_elements]).to eq(data: [{ id: element.id.to_s, type: :element }, { id: fixed_element.id.to_s, type: :element }])
-      else
-        expect(subject[:elements]).to eq(
-          data: [
-            { id: element.id.to_s, type: :element },
-            { id: deprecated_element.id.to_s, type: :element },
-          ],
-        )
-        expect(subject[:all_elements]).to eq(
-          data: [
-            { id: element.id.to_s, type: :element },
-            { id: fixed_element.id.to_s, type: :element },
-            { id: deprecated_element.id.to_s, type: :element },
-          ],
-        )
-      end
+    it "has the right keys and values, and does not include trashed elements" do
+      expect(subject[:elements]).to eq(data: [{ id: element.id.to_s, type: :element }])
       expect(subject[:fixed_elements]).to eq(data: [{ id: fixed_element.id.to_s, type: :element }])
+      expect(subject[:all_elements]).to eq(data: [{ id: element.id.to_s, type: :element }, { id: fixed_element.id.to_s, type: :element }])
       expect(subject[:language]).to eq(data: { id: page.language_id.to_s, type: :language })
     end
   end


### PR DESCRIPTION
This reverts #26 and #28

We agreed on keeping the deprecated elements in the response and add the attribute to the serializer (upcoming PR) instead. The frontend should decide what to do with deprecated elements and contents.