### PR TITLE
Add deprecated attribute to elements and contents

### DIFF
--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -11,6 +11,11 @@ module Alchemy
         :created_at,
         :updated_at,
       )
+
+      attribute :deprecated do |element|
+        !!element.definition[:deprecated]
+      end
+
       belongs_to :parent_element, record_type: :element, serializer: self
 
       belongs_to :page, record_type: :page, serializer: ::Alchemy::JsonApi::PageSerializer

--- a/lib/alchemy/json_api/essence_serializer.rb
+++ b/lib/alchemy/json_api/essence_serializer.rb
@@ -11,6 +11,9 @@ module Alchemy
         klass.attribute :role do |essence|
           essence.content.name
         end
+        klass.attribute :deprecated do |essence|
+          !!essence.content.definition[:deprecated]
+        end
       end
     end
   end

--- a/lib/alchemy/json_api/test_support/essence_serializer_behaviour.rb
+++ b/lib/alchemy/json_api/test_support/essence_serializer_behaviour.rb
@@ -5,6 +5,15 @@ RSpec.shared_examples "an essence serializer" do
 
     it "has the right keys and values" do
       expect(subject).to have_key(:ingredient)
+      expect(subject[:deprecated]).to be(false)
+    end
+
+    context "a deprecated content" do
+      let(:content) { FactoryBot.create(:alchemy_content, name: "intro", element: element) }
+
+      it "has deprecated attribute set to true" do
+        expect(subject[:deprecated]).to eq(true)
+      end
     end
   end
 

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -160,3 +160,6 @@
   fixed: true
   unique: true
   nestable_elements: [text]
+
+- name: old
+  deprecated: true

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -14,6 +14,7 @@
   contents:
   - name: intro
     type: EssenceText
+    deprecated: true
   - name: headline
     type: EssenceText
     settings:

--- a/spec/serializers/alchemy/json_api/element_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/element_serializer_spec.rb
@@ -27,7 +27,18 @@ RSpec.describe Alchemy::JsonApi::ElementSerializer do
       expect(subject[:created_at]).to eq(element.created_at)
       expect(subject[:updated_at]).to eq(element.updated_at)
       expect(subject[:position]).to eq(element.position)
+      expect(subject[:deprecated]).to eq(false)
       expect(subject.keys).not_to include(:tag_list, :display_name)
+    end
+
+    context "a deprecated element" do
+      let(:element) do
+        FactoryBot.create(:alchemy_element, name: "old")
+      end
+
+      it "has deprecated attribute set to true" do
+        expect(subject[:deprecated]).to eq(true)
+      end
     end
 
     context "with admin set to true" do


### PR DESCRIPTION
Adds the `deprecated` attribute to elements and essence serializers. This attribute has been introduced in Alchemy 5.2