### PR TITLE
Remove admin features from serializers

### DIFF
--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -25,11 +25,6 @@ module Alchemy
       end
 
       has_many :nested_elements, record_type: :element, serializer: self
-
-      with_options if: ->(_, params) { params[:admin] == true } do
-        attribute :tag_list
-        attribute :display_name, &:display_name_with_preview_text
-      end
     end
   end
 end

--- a/app/serializers/alchemy/json_api/language_serializer.rb
+++ b/app/serializers/alchemy/json_api/language_serializer.rb
@@ -18,12 +18,6 @@ module Alchemy
       end
       has_many :pages
       has_one :root_page, record_type: :page, serializer: ::Alchemy::JsonApi::PageSerializer
-
-      with_options if: ->(_, params) { params[:admin] == true } do
-        attribute :created_at
-        attribute :updated_at
-        attribute :public
-      end
     end
   end
 end

--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -24,11 +24,6 @@ module Alchemy
       has_many :all_elements, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer do |page|
         page.all_elements.select { |e| e.public? && !e.trashed? }
       end
-
-      with_options if: ->(_, params) { params[:admin] == true } do
-        attribute :tag_list
-        attribute :status
-      end
     end
   end
 end

--- a/spec/serializers/alchemy/json_api/element_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/element_serializer_spec.rb
@@ -40,15 +40,6 @@ RSpec.describe Alchemy::JsonApi::ElementSerializer do
         expect(subject[:deprecated]).to eq(true)
       end
     end
-
-    context "with admin set to true" do
-      let(:options) { { params: { admin: true } } }
-
-      it "includes admin-only attributes" do
-        expect(subject[:tag_list]).to eq(["Tag1", "Tag2"])
-        expect(subject[:display_name]).to eq("Article: ")
-      end
-    end
   end
 
   describe "relationships" do

--- a/spec/serializers/alchemy/json_api/language_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/language_serializer_spec.rb
@@ -22,17 +22,6 @@ RSpec.describe Alchemy::JsonApi::LanguageSerializer do
       expect(attributes[:country_code]).to eq("DE")
       expect(attributes[:locale]).to eq("de")
     end
-
-    context "with admin set to true" do
-      let(:options) { { params: { admin: true } } }
-
-      it "includes admin-only attributes" do
-        attributes = subject[:data][:attributes]
-        expect(attributes[:created_at]).to be_present
-        expect(attributes[:updated_at]).to be_present
-        expect(attributes[:public]).to be true
-      end
-    end
   end
 
   describe "relationships" do

--- a/spec/serializers/alchemy/json_api/page_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/page_serializer_spec.rb
@@ -33,22 +33,6 @@ RSpec.describe Alchemy::JsonApi::PageSerializer do
       expect(attributes[:updated_at]).to eq(page.updated_at)
       expect(attributes.keys).not_to include(:tag_list, :status)
     end
-
-    context "with admin set to true" do
-      let(:options) { { params: { admin: true } } }
-
-      it "includes admin-only attributes" do
-        attributes = subject[:data][:attributes]
-        expect(attributes[:tag_list]).to eq(["Tag1", "Tag2"])
-        expect(attributes[:status]).to eq(
-          {
-            public: false,
-            locked: false,
-            restricted: false,
-          },
-        )
-      end
-    end
   end
 
   describe "relationships" do


### PR DESCRIPTION
We currently building the public frontend API with this and try to make
this fast and feature parity as a replacement to the legacy JSON api from
Alchemy core.

Therefore we want to concentrate on the frontend attributes now and remove
currently not even supported admin flag.