### PR TITLE
Add database IDs to Alchemy JSON serializers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ spec/dummy/db/*.sqlite3
 spec/dummy/public
 Gemfile.lock
 .ruby-version
+.idea

--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -5,6 +5,7 @@ module Alchemy
       include JSONAPI::Serializer
 
       attributes(
+        :id,
         :name,
         :fixed,
         :position,

--- a/app/serializers/alchemy/json_api/language_serializer.rb
+++ b/app/serializers/alchemy/json_api/language_serializer.rb
@@ -5,6 +5,7 @@ module Alchemy
       include JSONAPI::Serializer
 
       attributes(
+        :id,
         :name,
         :language_code,
         :country_code,

--- a/app/serializers/alchemy/json_api/node_serializer.rb
+++ b/app/serializers/alchemy/json_api/node_serializer.rb
@@ -4,7 +4,7 @@ module Alchemy
     class NodeSerializer
       include JSONAPI::Serializer
 
-      attributes :name
+      attributes :id, :name
       attribute :link_url, &:url
       attribute :link_title, &:title
       attribute :link_nofollow, &:nofollow

--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -7,6 +7,7 @@ module Alchemy
       ELEMENT_SERIALIZER = ::Alchemy::JsonApi::ElementSerializer
 
       attributes(
+        :id,
         :name,
         :urlname,
         :page_layout,

--- a/lib/alchemy/json_api/essence_serializer.rb
+++ b/lib/alchemy/json_api/essence_serializer.rb
@@ -7,7 +7,7 @@ module Alchemy
         klass.has_one :element, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer do |essence|
           essence.content.element
         end
-        klass.attributes :ingredient
+        klass.attributes :id, :ingredient
         klass.attribute :role do |essence|
           essence.content.name
         end

--- a/spec/serializers/alchemy/json_api/element_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/element_serializer_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Alchemy::JsonApi::ElementSerializer do
     subject { serializer.serializable_hash[:data][:attributes] }
 
     it "has the right keys and values" do
+      expect(subject[:id]).to eq(element.id)
       expect(subject[:name]).to eq("article")
       expect(subject[:fixed]).to eq(false)
       expect(subject[:created_at]).to eq(element.created_at)

--- a/spec/serializers/alchemy/json_api/language_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/language_serializer_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Alchemy::JsonApi::LanguageSerializer do
 
     it "has the right keys and values" do
       attributes = subject[:data][:attributes]
+      expect(subject[:id]).to eq(language.id)
       expect(attributes[:name]).to eq("Deutsch")
       expect(attributes[:language_code]).to eq("de")
       expect(attributes[:country_code]).to eq("DE")

--- a/spec/serializers/alchemy/json_api/node_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/node_serializer_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Alchemy::JsonApi::NodeSerializer do
 
     it "has the right keys and values" do
       attributes = subject[:data][:attributes]
+      expect(attributes[:id]).to eq(node.id)
       expect(attributes[:name]).to eq("A Node")
       expect(attributes[:link_title]).to eq("Pop-up explanation")
       expect(attributes[:link_url]).to eq("/acdc")

--- a/spec/serializers/alchemy/json_api/page_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/page_serializer_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Alchemy::JsonApi::PageSerializer do
 
     it "has the right keys and values" do
       attributes = subject[:data][:attributes]
+      expect(attributes[:id]).to eq(alchemy_page.id)
       expect(attributes[:urlname]).to eq("a-page")
       expect(attributes[:name]).to eq(page.name)
       expect(attributes[:page_layout]).to eq("standard")


### PR DESCRIPTION
JSON:API returns a top-level ID for each serialized object, however this ID is always a string and does not necessarily correspond to a database ID. It's an internal ID used to match objects within the JSON response. Therefore, we should be including the actual database ID for each page, element, etc. as an attribute in our serializers. This has the added benefit of causing the ID to be encoded as an integer (not a string) in the JSON response.

Read more about JSON:API identifiers here:
https://jsonapi.org/format/#document-resource-object-identification