### PR TITLE
Fix essence serializer RSpec behavior

### DIFF
--- a/lib/alchemy/json_api/test_support/essence_serializer_behaviour.rb
+++ b/lib/alchemy/json_api/test_support/essence_serializer_behaviour.rb
@@ -11,6 +11,15 @@ RSpec.shared_examples "an essence serializer" do
     context "a deprecated content" do
       let(:content) { FactoryBot.create(:alchemy_content, name: "intro", element: element) }
 
+      before do
+        expect(content).to receive(:definition).at_least(:once) do
+          {
+            name: "intro",
+            deprecated: true,
+          }
+        end
+      end
+
       it "has deprecated attribute set to true" do
         expect(subject[:deprecated]).to eq(true)
       end


### PR DESCRIPTION
This only works with this dummy app and its `elements.yml` if we do not also stub the content definition.