### PR TITLE
Add missing Alchemy::Logger include to Element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ spec/dummy/db/*.sqlite3
 spec/dummy/public
 Gemfile.lock
 .ruby-version
+.idea

--- a/app/models/alchemy/json_api/element.rb
+++ b/app/models/alchemy/json_api/element.rb
@@ -1,6 +1,7 @@
 module Alchemy
   module JsonApi
     class Element < BaseRecord
+      include Alchemy::Logger
       include Alchemy::Element::Definitions
       include Alchemy::Element::ElementContents
 


### PR DESCRIPTION
The `Alchemy::Element::ElementContents` mixin can call `Alchemy::Logger#log_warning` if content definitions are missing. The `Alchemy::Logger` module needs to be included in `Alchemy::JsonApi::Element`, otherwise we get a method missing error for `#log_warning` instead of actually logging a warning.

Fixes this:

```
NoMethodError (undefined method `log_warning' for #<Alchemy::JsonApi::Element:0x00007fefd9dfe5a0>):
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activemodel-6.0.3.4/lib/active_model/attribute_methods.rb:432:in `method_missing'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/bundler/gems/alchemy_cms-efd7feab0462/app/models/alchemy/element/element_contents.rb:103:in `content_definition_for'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/bundler/gems/alchemy_cms-efd7feab0462/app/models/alchemy/content/factory.rb:113:in `definition'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/bundler/gems/alchemy_cms-efd7feab0462/app/models/alchemy/content.rb:100:in `settings'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/bundler/gems/alchemy_cms-efd7feab0462/app/models/alchemy/essence_picture.rb:81:in `picture_url_options'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/bundler/gems/alchemy_cms-efd7feab0462/app/models/alchemy/essence_picture.rb:65:in `picture_url'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/helpers.rb:9:in `call_proc'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/scalar.rb:14:in `serialize'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:49:in `block in attributes_hash'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:48:in `each'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:48:in `each_with_object'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:48:in `attributes_hash'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:82:in `record_hash'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:196:in `block (2 levels) in get_included_records'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:182:in `each'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:182:in `block in get_included_records'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:171:in `each'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:171:in `each_with_object'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:171:in `get_included_records'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:187:in `block (2 levels) in get_included_records'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:182:in `each'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:182:in `block in get_included_records'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:171:in `each'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:171:in `each_with_object'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/serialization_core.rb:171:in `get_included_records'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/object_serializer.rb:65:in `block in hash_for_collection'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activerecord-6.0.3.4/lib/active_record/relation/delegation.rb:87:in `each'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activerecord-6.0.3.4/lib/active_record/relation/delegation.rb:87:in `each'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/object_serializer.rb:63:in `hash_for_collection'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi-serializer-2.1.0/lib/fast_jsonapi/object_serializer.rb:38:in `serializable_hash'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi.rb-1.6.0/lib/jsonapi/rails.rb:143:in `serializer_to_json'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi.rb-1.6.0/lib/jsonapi/rails.rb:106:in `block in add_renderer!'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal/renderers.rb:150:in `block in _render_to_body_with_renderer'
  /Users/pelargir/.rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/set.rb:328:in `each_key'
  /Users/pelargir/.rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/set.rb:328:in `each'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal/renderers.rb:146:in `_render_to_body_with_renderer'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal/renderers.rb:142:in `render_to_body'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/abstract_controller/rendering.rb:25:in `render'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal/rendering.rb:36:in `render'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal/instrumentation.rb:44:in `block (2 levels) in render'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activesupport-6.0.3.4/lib/active_support/core_ext/benchmark.rb:14:in `block in ms'
  /Users/pelargir/.rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/benchmark.rb:308:in `realtime'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activesupport-6.0.3.4/lib/active_support/core_ext/benchmark.rb:14:in `ms'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal/instrumentation.rb:44:in `block in render'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal/instrumentation.rb:84:in `cleanup_view_runtime'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activerecord-6.0.3.4/lib/active_record/railties/controller_runtime.rb:34:in `cleanup_view_runtime'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal/instrumentation.rb:43:in `render'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/alchemy-json_api-0.12.1/app/controllers/alchemy/json_api/pages_controller.rb:13:in `block (2 levels) in index'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi.rb-1.6.0/lib/jsonapi/pagination.rb:26:in `jsonapi_paginate'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/alchemy-json_api-0.12.1/app/controllers/alchemy/json_api/pages_controller.rb:12:in `block in index'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/jsonapi.rb-1.6.0/lib/jsonapi/filtering.rb:40:in `jsonapi_filter'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/alchemy-json_api-0.12.1/app/controllers/alchemy/json_api/pages_controller.rb:11:in `index'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/abstract_controller/base.rb:195:in `process_action'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal/rendering.rb:30:in `process_action'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/abstract_controller/callbacks.rb:42:in `block in process_action'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:135:in `run_callbacks'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/abstract_controller/callbacks.rb:41:in `process_action'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal/rescue.rb:22:in `process_action'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal/instrumentation.rb:33:in `block in process_action'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activesupport-6.0.3.4/lib/active_support/notifications.rb:180:in `block in instrument'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activesupport-6.0.3.4/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activesupport-6.0.3.4/lib/active_support/notifications.rb:180:in `instrument'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal/instrumentation.rb:32:in `process_action'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal/params_wrapper.rb:245:in `process_action'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activerecord-6.0.3.4/lib/active_record/railties/controller_runtime.rb:27:in `process_action'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/abstract_controller/base.rb:136:in `process'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionview-6.0.3.4/lib/action_view/rendering.rb:39:in `process'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal.rb:190:in `dispatch'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_controller/metal.rb:254:in `dispatch'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/routing/route_set.rb:50:in `dispatch'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/routing/route_set.rb:33:in `serve'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/journey/router.rb:49:in `block in serve'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/journey/router.rb:32:in `each'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/journey/router.rb:32:in `serve'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/routing/route_set.rb:834:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/railties-6.0.3.4/lib/rails/engine.rb:527:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/railties-6.0.3.4/lib/rails/railtie.rb:190:in `public_send'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/railties-6.0.3.4/lib/rails/railtie.rb:190:in `method_missing'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/routing/mapper.rb:19:in `block in <class:Constraints>'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/routing/mapper.rb:48:in `serve'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/journey/router.rb:49:in `block in serve'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/journey/router.rb:32:in `each'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/journey/router.rb:32:in `serve'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/routing/route_set.rb:834:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:192:in `call!'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:169:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:192:in `call!'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:169:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/dragonfly-1.2.1/lib/dragonfly/middleware.rb:14:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-attack-6.3.1/lib/rack/attack.rb:97:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/rack/agent_hooks.rb:30:in `traced_call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/rack/browser_monitoring.rb:33:in `traced_call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-attack-6.3.1/lib/rack/attack.rb:104:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/Projects/candlescience/CSpree/lib/cs/middleware/add_custom_params_to_new_relic.rb:17:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/warden-1.2.9/lib/warden/manager.rb:36:in `block in call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/warden-1.2.9/lib/warden/manager.rb:34:in `catch'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/warden-1.2.9/lib/warden/manager.rb:34:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-2.2.3/lib/rack/tempfile_reaper.rb:15:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-2.2.3/lib/rack/etag.rb:27:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-2.2.3/lib/rack/conditional_get.rb:27:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-2.2.3/lib/rack/head.rb:12:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/http/content_security_policy.rb:18:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-2.2.3/lib/rack/session/abstract/id.rb:266:in `context'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-2.2.3/lib/rack/session/abstract/id.rb:260:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/middleware/cookies.rb:648:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activerecord-6.0.3.4/lib/active_record/migration.rb:567:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/middleware/callbacks.rb:27:in `block in call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activesupport-6.0.3.4/lib/active_support/callbacks.rb:101:in `run_callbacks'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/middleware/callbacks.rb:26:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/middleware/executor.rb:14:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/bugsnag-6.19.0/lib/bugsnag/integrations/rack.rb:51:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/better_errors-2.9.1/lib/better_errors/middleware.rb:87:in `protected_app_call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/better_errors-2.9.1/lib/better_errors/middleware.rb:82:in `better_errors_call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/better_errors-2.9.1/lib/better_errors/middleware.rb:60:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/middleware/debug_exceptions.rb:32:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/lograge-0.11.2/lib/lograge/rails_ext/rack/logger.rb:15:in `call_app'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/railties-6.0.3.4/lib/rails/rack/logger.rb:26:in `block in call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activesupport-6.0.3.4/lib/active_support/tagged_logging.rb:80:in `block in tagged'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activesupport-6.0.3.4/lib/active_support/tagged_logging.rb:28:in `tagged'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activesupport-6.0.3.4/lib/active_support/tagged_logging.rb:80:in `tagged'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/railties-6.0.3.4/lib/rails/rack/logger.rb:26:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/sprockets-rails-3.2.2/lib/sprockets/rails/quiet_assets.rb:13:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/request_store-1.5.0/lib/request_store/middleware.rb:19:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-timeout-0.6.0/lib/rack/timeout/core.rb:114:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/middleware/request_id.rb:27:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-2.2.3/lib/rack/method_override.rb:24:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/Projects/candlescience/CSpree/lib/cs/middleware/handle_unknown_http_methods.rb:17:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-2.2.3/lib/rack/runtime.rb:22:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/activesupport-6.0.3.4/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/middleware/executor.rb:14:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/middleware/static.rb:126:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-2.2.3/lib/rack/sendfile.rb:110:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/dragonfly-1.2.1/lib/dragonfly/cookie_monster.rb:9:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/actionpack-6.0.3.4/lib/action_dispatch/middleware/host_authorization.rb:82:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-uri_sanitizer-0.0.2/lib/rack/uri_sanitizer.rb:14:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-utf8_sanitizer-1.7.0/lib/rack/utf8_sanitizer.rb:22:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-cors-1.1.1/lib/rack/cors.rb:100:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/webpacker-5.2.1/lib/webpacker/dev_server_proxy.rb:25:in `perform_request'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/rack-proxy-0.6.5/lib/rack/proxy.rb:57:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/railties-6.0.3.4/lib/rails/engine.rb:527:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/newrelic_rpm-6.13.1/lib/new_relic/agent/instrumentation/middleware_tracing.rb:101:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/puma-5.1.1/lib/puma/configuration.rb:246:in `call'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/puma-5.1.1/lib/puma/request.rb:76:in `block in handle_request'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/puma-5.1.1/lib/puma/thread_pool.rb:337:in `with_force_shutdown'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/puma-5.1.1/lib/puma/request.rb:75:in `handle_request'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/puma-5.1.1/lib/puma/server.rb:431:in `process_client'
  /Users/pelargir/.rvm/gems/ruby-2.7.2@cs_spree_3_0/gems/puma-5.1.1/lib/puma/thread_pool.rb:145:in `block in spawn_thread'


method=GET path=/jsonapi/pages.json format=json controller=Alchemy::JsonApi::PagesController action=index status=500 duration=4340.12 view=0.20 db=210.81 params={"include"=>"all_elements.essences.taxonomy.taxons", "page"=>{"number"=>"4"}} env=development timestamp=2021-01-26T19:11:33Z total=-4.34012 seconds ip=127.0.0.1 host=lvh.me user_agent=axios/0.21.1 masquerading_user= order=
```