### PR TITLE
Remove tests for trashed elements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
         alchemy_branch:
           - 5.0-stable
           - 5.1-stable
+          - 5.2-stable
           - main
     env:
       ALCHEMY_BRANCH: ${{ matrix.alchemy_branch }}

--- a/spec/models/alchemy/json_api/element_spec.rb
+++ b/spec/models/alchemy/json_api/element_spec.rb
@@ -10,13 +10,11 @@ RSpec.describe Alchemy::JsonApi::Element, type: :model do
 
       let!(:public_one) { FactoryBot.create(:alchemy_element, public: true) }
       let!(:non_public) { FactoryBot.create(:alchemy_element, public: false) }
-      let!(:trashed) { FactoryBot.create(:alchemy_element, public: true).tap(&:trash!) }
 
       it "returns public available elements" do
         # expecting the ids here because the factorys class is not our decorator class
         expect(available).to include(public_one.id)
         expect(available).to_not include(non_public.id)
-        expect(available).to_not include(trashed.id)
       end
     end
   end

--- a/spec/models/alchemy/json_api/page_spec.rb
+++ b/spec/models/alchemy/json_api/page_spec.rb
@@ -85,14 +85,6 @@ RSpec.describe Alchemy::JsonApi::Page, type: :model do
       end
     end
 
-    context "with trashed elements" do
-      let!(:trashed_element) { FactoryBot.create(:alchemy_element, page: page).tap(&:trash!) }
-
-      it "does not contain trashed elements" do
-        expect(all_element_ids).to_not include(trashed_element.id)
-      end
-    end
-
     context "with hidden elements" do
       let!(:hidden_element) { FactoryBot.create(:alchemy_element, page: page, public: false) }
 
@@ -135,14 +127,6 @@ RSpec.describe Alchemy::JsonApi::Page, type: :model do
       end
     end
 
-    context "with trashed elements" do
-      let!(:trashed_element) { FactoryBot.create(:alchemy_element, page: page).tap(&:trash!) }
-
-      it "does not contain trashed elements" do
-        expect(element_ids).to_not include(trashed_element.id)
-      end
-    end
-
     context "with hidden elements" do
       let(:hidden_element) { FactoryBot.create(:alchemy_element, page: page, public: false) }
 
@@ -167,14 +151,6 @@ RSpec.describe Alchemy::JsonApi::Page, type: :model do
 
     it "returns a ordered active record collection of fixed elements on that page" do
       expect(fixed_elements).to eq([element_3.id, element_1.id, element_2.id])
-    end
-
-    context "with trashed fixed elements" do
-      let!(:trashed_element) { FactoryBot.create(:alchemy_element, page: page, fixed: true).tap(&:trash!) }
-
-      it "does not contain trashed fixed elements" do
-        expect(fixed_elements).to_not include(trashed_element.id)
-      end
     end
 
     context "with hidden fixed elements" do

--- a/spec/serializers/alchemy/json_api/page_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/page_serializer_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe Alchemy::JsonApi::PageSerializer do
     let!(:element) { FactoryBot.create(:alchemy_element, page: alchemy_page) }
     let!(:fixed_element) { FactoryBot.create(:alchemy_element, page: alchemy_page, fixed: true) }
     let!(:non_public_element) { FactoryBot.create(:alchemy_element, page: alchemy_page, public: false) }
-    let!(:trashed_element) { FactoryBot.create(:alchemy_element, page: alchemy_page).tap(&:trash!) }
 
     subject { serializer.serializable_hash[:data][:relationships] }
 


### PR DESCRIPTION
Alchemy 6 removes this feature and in old versions it is deprecated

