### PR TITLE
Add legacy URLs to page serializer

### DIFF
--- a/app/models/alchemy/json_api/page.rb
+++ b/app/models/alchemy/json_api/page.rb
@@ -10,6 +10,8 @@ module Alchemy
         class_name: "Alchemy::JsonApi::Element",
         inverse_of: :page
 
+      has_many :legacy_urls, class_name: "Alchemy::LegacyPageUrl"
+
       scope :published, -> {
           where("#{table_name}.public_on <= :time AND " \
                 "(#{table_name}.public_until IS NULL " \

--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -18,6 +18,10 @@ module Alchemy
         :updated_at,
       )
 
+      attribute :legacy_urls do |page|
+        page.legacy_urls.map(&:urlname)
+      end
+
       belongs_to :language, record_type: :language, serializer: ::Alchemy::JsonApi::LanguageSerializer
 
       # All public elements of this page regardless of if they are fixed or nested.

--- a/spec/models/alchemy/json_api/page_spec.rb
+++ b/spec/models/alchemy/json_api/page_spec.rb
@@ -102,6 +102,20 @@ RSpec.describe Alchemy::JsonApi::Page, type: :model do
     end
   end
 
+  describe "#legacy_urls" do
+    let(:page) { FactoryBot.create(:alchemy_page) }
+    let!(:legacy_url_1) { Alchemy::LegacyPageUrl.create(page: page, urlname: "/one") }
+    let!(:legacy_url_2) { Alchemy::LegacyPageUrl.create(page: page, urlname: "/two") }
+
+    subject(:all_legacy_url_ids) do
+      described_class.find(page.id).legacy_urls.map(&:id)
+    end
+
+    it "returns a active record collection of legacy URLs on that page" do
+      expect(all_legacy_url_ids).to eq([legacy_url_1.id, legacy_url_2.id])
+    end
+  end
+
   describe "#elements" do
     let(:page) { FactoryBot.create(:alchemy_page) }
     let!(:element_1) { FactoryBot.create(:alchemy_element, page: page) }

--- a/spec/serializers/alchemy/json_api/page_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/page_serializer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Alchemy::JsonApi::PageSerializer do
       tag_list: "Tag1,Tag2",
     )
   end
+  let!(:legacy_url) { Alchemy::LegacyPageUrl.create(urlname: "/other", page: alchemy_page) }
   let(:options) { {} }
   let(:page) { Alchemy::JsonApi::Page.find(alchemy_page.id) }
 
@@ -31,6 +32,7 @@ RSpec.describe Alchemy::JsonApi::PageSerializer do
       expect(attributes[:meta_description]).to eq("Meta Description")
       expect(attributes[:created_at]).to eq(page.created_at)
       expect(attributes[:updated_at]).to eq(page.updated_at)
+      expect(attributes[:legacy_urls]).to eq(["/other"])
       expect(attributes.keys).not_to include(:tag_list, :status)
     end
   end


### PR DESCRIPTION
This adds legacy URLs to the page serializer. Since legacy URLs only have one useful field (`urlname`) I opted to include these as an attribute on the page instead of creating an extra serializer for legacy URLs.