### PR TITLE
Preload legacy page URLs

### DIFF
--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -51,6 +51,7 @@ module Alchemy
         base_page_scope.
           with_language(Language.current).
           preload(
+            :legacy_urls,
             language: { nodes: [:parent, :page, :children] },
             all_elements: { contents: { essence: :ingredient_association } }
           )

--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -50,7 +50,10 @@ module Alchemy
       def page_scope_with_includes
         base_page_scope.
           with_language(Language.current).
-          preload(language: { nodes: [:parent, :page, :children] }, all_elements: { contents: { essence: :ingredient_association } })
+          preload(
+            language: { nodes: [:parent, :page, :children] },
+            all_elements: { contents: { essence: :ingredient_association } }
+          )
       end
 
       def base_page_scope


### PR DESCRIPTION
This eliminates an N+1 query in the pages controller by preloading legacy page URLs.