### PR TITLE
Serialize the new sanitized_body column from Alchemy

### DIFF
--- a/app/serializers/alchemy/json_api/essence_richtext_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_richtext_serializer.rb
@@ -7,6 +7,7 @@ module Alchemy
       include EssenceSerializer
       attributes(
         :body,
+        :sanitized_body,
         :stripped_body,
       )
     end

--- a/spec/serializers/alchemy/json_api/essence_richtext_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/essence_richtext_serializer_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe Alchemy::JsonApi::EssenceRichtextSerializer do
   let(:content) { FactoryBot.create(:alchemy_content, element: element) }
   let(:essence) do
     Alchemy::EssenceRichtext.create(
-      body: "<h3>Hello</h3>",
-      stripped_body: "Hello",
+      body: "<h3 style=\"color: red;\">Hello</h3>",
       content: content,
     )
   end
@@ -21,7 +20,8 @@ RSpec.describe Alchemy::JsonApi::EssenceRichtextSerializer do
     subject { serializer.serializable_hash[:data][:attributes] }
 
     it "has the right keys and values" do
-      expect(subject[:body]).to eq("<h3>Hello</h3>")
+      expect(subject[:body]).to eq("<h3 style=\"color: red;\">Hello</h3>")
+      expect(subject[:sanitized_body]).to eq("<h3>Hello</h3>")
       expect(subject[:stripped_body]).to eq("Hello")
     end
   end


### PR DESCRIPTION
This adds the new `sanitized_body` column from Alchemy 6 to the JSONAPI output.