### PR TITLE
Join to page version in PagesController

### DIFF
--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -79,9 +79,9 @@ module Alchemy
       def base_page_scope
         # cancancan is not able to merge our complex AR scopes for logged in users
         if can?(:edit_content, ::Alchemy::Page)
-          Alchemy::Page.all
+          Alchemy::Page.all.joins(page_version)
         else
-          Alchemy::Page.published
+          Alchemy::Page.published.joins(page_version)
         end
       end
 

--- a/spec/requests/alchemy/json_api/layout_pages_spec.rb
+++ b/spec/requests/alchemy/json_api/layout_pages_spec.rb
@@ -70,9 +70,9 @@ RSpec.describe "Alchemy::JsonApi::LayoutPagesController", type: :request do
           end
         end
 
-        it "finds the page" do
+        it "does not find the page" do
           get alchemy_json_api.layout_page_path(page.urlname)
-          expect(response).to have_http_status(200)
+          expect(response).to have_http_status(404)
         end
       end
     end
@@ -101,11 +101,11 @@ RSpec.describe "Alchemy::JsonApi::LayoutPagesController", type: :request do
           end
         end
 
-        it "returns all layout pages" do
+        it "returns all published layout pages" do
           get alchemy_json_api.layout_pages_path
           document = JSON.parse(response.body)
           expect(document["data"]).to include(have_id(layoutpage.id.to_s))
-          expect(document["data"]).to include(have_id(non_public_layout_page.id.to_s))
+          expect(document["data"]).not_to include(have_id(non_public_layout_page.id.to_s))
           expect(document["data"]).not_to include(have_id(public_page.id.to_s))
         end
       end

--- a/spec/requests/alchemy/json_api/pages_spec.rb
+++ b/spec/requests/alchemy/json_api/pages_spec.rb
@@ -90,9 +90,9 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
           end
         end
 
-        it "finds the page" do
+        it "does not find the page" do
           get alchemy_json_api.page_path(page.urlname)
-          expect(response).to have_http_status(200)
+          expect(response).to have_http_status(404)
         end
       end
     end
@@ -121,11 +121,11 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
           end
         end
 
-        it "returns all content pages" do
+        it "returns all published content pages" do
           get alchemy_json_api.pages_path
           document = JSON.parse(response.body)
           expect(document["data"]).not_to include(have_id(layoutpage.id.to_s))
-          expect(document["data"]).to include(have_id(non_public_page.id.to_s))
+          expect(document["data"]).not_to include(have_id(non_public_page.id.to_s))
           expect(document["data"]).to include(have_id(public_page.id.to_s))
         end
       end


### PR DESCRIPTION
When accessing an unpublished page as an admin, the previous code would
result in the API returning a 200 response and a page with no elements.
It is more correct to return a 404. By joining the pages to their
version, we make sure this happens.