### PR TITLE
Add ancestors relationship to page serializer

### DIFF
--- a/app/controllers/alchemy/json_api/admin/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/admin/pages_controller.rb
@@ -7,7 +7,7 @@ module Alchemy
 
         private
 
-        def page_version
+        def page_version_type
           :draft_version
         end
       end

--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -57,7 +57,7 @@ module Alchemy
               :legacy_urls,
               { language: { nodes: [:parent, :children, { page: { language: { site: :languages } } }] } },
               {
-                page_version => {
+                page_version_type => {
                   elements: [
                     :nested_elements,
                     { contents: { essence: :ingredient_association } },
@@ -68,20 +68,20 @@ module Alchemy
           )
       end
 
-      def page_version
+      def page_version_type
         :public_version
       end
 
       def api_page(page)
-        Alchemy::JsonApi::Page.new(page, page_version: page_version)
+        Alchemy::JsonApi::Page.new(page, page_version_type: page_version_type)
       end
 
       def base_page_scope
         # cancancan is not able to merge our complex AR scopes for logged in users
         if can?(:edit_content, ::Alchemy::Page)
-          Alchemy::Page.all.joins(page_version)
+          Alchemy::Page.all.joins(page_version_type)
         else
-          Alchemy::Page.published.joins(page_version)
+          Alchemy::Page.published.joins(page_version_type)
         end
       end
 

--- a/app/models/alchemy/json_api/page.rb
+++ b/app/models/alchemy/json_api/page.rb
@@ -36,6 +36,10 @@ module Alchemy
         @_fixed_element_ids ||= fixed_elements.map(&:id)
       end
 
+      def ancestor_ids
+        @_ancestor_ids ||= ancestors.map(&:id)
+      end
+
       private
 
       def element_repository

--- a/app/models/alchemy/json_api/page.rb
+++ b/app/models/alchemy/json_api/page.rb
@@ -1,8 +1,11 @@
 module Alchemy
   module JsonApi
     class Page < SimpleDelegator
-      def initialize(page, page_version: :public_version)
-        @page_version = page.public_send(page_version)
+      attr_reader :page_version_type, :page_version
+
+      def initialize(page, page_version_type: :public_version)
+        @page_version_type = page_version_type
+        @page_version = page.public_send(page_version_type)
         super(page)
       end
 
@@ -36,10 +39,10 @@ module Alchemy
       private
 
       def element_repository
-        return Alchemy::ElementsRepository.none unless @page_version
+        return Alchemy::ElementsRepository.none unless page_version
 
         # Need to use select here, otherwise rails would not eager load the elements correctly
-        Alchemy::ElementsRepository.new(@page_version.elements.select(&:public))
+        Alchemy::ElementsRepository.new(page_version.elements.select(&:public))
       end
     end
   end

--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -24,6 +24,12 @@ module Alchemy
 
       belongs_to :language, record_type: :language, serializer: ::Alchemy::JsonApi::LanguageSerializer
 
+      has_many :ancestors, record_type: :page, serializer: self do |page|
+        page.ancestors.map do |ancestor|
+          Alchemy::JsonApi::Page.new(ancestor, page_version_type: page.page_version_type)
+        end
+      end
+
       # All public elements of this page regardless of if they are fixed or nested.
       # Used for eager loading and should be used as the +include+ parameter of your query
       has_many :all_elements, record_type: :element, serializer: ELEMENT_SERIALIZER

--- a/spec/models/alchemy/json_api/page_spec.rb
+++ b/spec/models/alchemy/json_api/page_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Alchemy::JsonApi::Page, type: :model do
       end
 
       context "with draft_version passed as page_version" do
-        let(:json_api_page) { described_class.new(page, page_version: :draft_version) }
+        let(:json_api_page) { described_class.new(page, page_version_type: :draft_version) }
         let!(:element_4) { FactoryBot.create(:alchemy_element, page_version: page.draft_version) }
 
         it "contains elements only from draft version" do
@@ -39,7 +39,7 @@ RSpec.describe Alchemy::JsonApi::Page, type: :model do
 
     context "with page_version not present" do
       let(:page) { FactoryBot.create(:alchemy_page) }
-      let(:json_api_page) { described_class.new(page, page_version: :public_version) }
+      let(:json_api_page) { described_class.new(page, page_version_type: :public_version) }
 
       it "contains elements only from draft version" do
         is_expected.to match([])

--- a/spec/serializers/alchemy/json_api/page_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/page_serializer_spec.rb
@@ -66,5 +66,13 @@ RSpec.describe Alchemy::JsonApi::PageSerializer do
         expect(subject[:language]).to eq(data: { id: page.language_id.to_s, type: :language })
       end
     end
+
+    it "has ancestors relationship" do
+      expect(subject[:ancestors]).to eq(
+        data: [
+          { id: page.parent_id.to_s, type: :page },
+        ],
+      )
+    end
   end
 end


### PR DESCRIPTION
Useful if you want to serialize the page categorizations in a breadcrumb for instance.