### PR TITLE
Add caching

### DIFF
--- a/app/controllers/alchemy/json_api/admin/layout_pages_controller.rb
+++ b/app/controllers/alchemy/json_api/admin/layout_pages_controller.rb
@@ -6,7 +6,7 @@ module Alchemy
         private
 
         def page_scope
-          page_scope_with_includes.layoutpages
+          base_page_scope.layoutpages
         end
       end
     end

--- a/app/controllers/alchemy/json_api/admin/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/admin/pages_controller.rb
@@ -4,8 +4,17 @@ module Alchemy
     module Admin
       class PagesController < JsonApi::PagesController
         prepend_before_action { authorize! :edit_content, Alchemy::Page }
+        before_action :set_current_preview, only: :show
 
         private
+
+        def set_current_preview
+          Alchemy::Page.current_preview = @page
+        end
+
+        def last_modified_for(page)
+          page.updated_at
+        end
 
         def page_version_type
           :draft_version

--- a/app/controllers/alchemy/json_api/admin/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/admin/pages_controller.rb
@@ -8,6 +8,14 @@ module Alchemy
 
         private
 
+        def cache_duration
+          0
+        end
+
+        def caching_options
+          { public: false, must_revalidate: true }
+        end
+
         def set_current_preview
           Alchemy::Page.current_preview = @page
         end

--- a/app/controllers/alchemy/json_api/layout_pages_controller.rb
+++ b/app/controllers/alchemy/json_api/layout_pages_controller.rb
@@ -5,7 +5,7 @@ module Alchemy
       private
 
       def page_scope
-        page_scope_with_includes.layoutpages
+        base_page_scope.layoutpages
       end
     end
   end

--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -8,11 +8,17 @@ module Alchemy
       def index
         allowed = [:page_layout, :urlname]
 
-        jsonapi_filter(page_scope, allowed) do |filtered|
-          # decorate with our page model that has a eager loaded elements collection
-          pages = filtered.result.map { |page| api_page(page) }
-          jsonapi_paginate(pages) do |paginated|
-            render jsonapi: paginated
+        jsonapi_filter(page_scope, allowed) do |filtered_pages|
+          @pages = filtered_pages.result
+          if stale?(last_modified: @pages.maximum(:published_at), etag: @pages.max_by(&:cache_key).cache_key)
+            # Only load pages with all includes when browser cache is stale
+            jsonapi_filter(page_scope_with_includes, allowed) do |filtered|
+              # decorate with our page model that has a eager loaded elements collection
+              filtered_pages = filtered.result.map { |page| api_page(page) }
+              jsonapi_paginate(filtered_pages) do |paginated|
+                render jsonapi: paginated
+              end
+            end
           end
         end
       end

--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -21,6 +21,8 @@ module Alchemy
             end
           end
         end
+
+        expires_in cache_duration, caching_options.merge(public: @pages.none?(&:restricted?))
       end
 
       def show
@@ -28,9 +30,19 @@ module Alchemy
           # Only load page with all includes when browser cache is stale
           render jsonapi: api_page(load_page)
         end
+
+        expires_in cache_duration, caching_options.merge(public: !@page.restricted?)
       end
 
       private
+
+      def cache_duration
+        ENV.fetch("ALCHEMY_JSON_API_CACHE_DURATION", 3).to_i.hours
+      end
+
+      def caching_options
+        { must_revalidate: true }
+      end
 
       # Get page w/o includes to get cache key
       def load_page_for_cache_key

--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -22,7 +22,7 @@ module Alchemy
           end
         end
 
-        expires_in cache_duration, caching_options.merge(public: @pages.none?(&:restricted?))
+        expires_in cache_duration, { public: @pages.none?(&:restricted?) }.merge(caching_options)
       end
 
       def show
@@ -31,7 +31,7 @@ module Alchemy
           render jsonapi: api_page(load_page)
         end
 
-        expires_in cache_duration, caching_options.merge(public: !@page.restricted?)
+        expires_in cache_duration, { public: !@page.restricted? }.merge(caching_options)
       end
 
       private

--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -12,6 +12,8 @@ module Alchemy
         :updated_at,
       )
 
+      cache_options store: Rails.cache, namespace: "alchemy-jsonapi"
+
       attribute :deprecated do |element|
         !!element.definition[:deprecated]
       end

--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -18,6 +18,8 @@ module Alchemy
         :updated_at,
       )
 
+      cache_options store: Rails.cache, namespace: "alchemy-jsonapi"
+
       attribute :legacy_urls do |page|
         page.legacy_urls.map(&:urlname)
       end

--- a/spec/controllers/alchemy/json_api/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/json_api/admin/pages_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "alchemy/devise/test_support/factories"
+require "alchemy/test_support/integration_helpers"
+
+RSpec.describe Alchemy::JsonApi::Admin::PagesController do
+  include Devise::Test::ControllerHelpers
+  include Alchemy::TestSupport::IntegrationHelpers
+
+  routes { Alchemy::JsonApi::Engine.routes }
+
+  before { authorize_user(FactoryBot.build(:alchemy_author_user)) }
+
+  describe "#show" do
+    let(:page) { FactoryBot.create(:alchemy_page) }
+
+    it "stores page as preview" do
+      get :show, params: { path: page.urlname }
+      expect(Alchemy::Page.current_preview).to eq(page.id)
+    end
+  end
+end

--- a/spec/requests/alchemy/json_api/admin/layout_pages_spec.rb
+++ b/spec/requests/alchemy/json_api/admin/layout_pages_spec.rb
@@ -102,6 +102,26 @@ RSpec.describe "Alchemy::JsonApi::Admin::LayoutPagesController", type: :request 
           }
         )
       end
+
+      it "sets cache headers" do
+        get alchemy_json_api.admin_layout_page_path(page)
+        expect(response.headers["Last-Modified"]).to eq(page.updated_at.utc.httpdate)
+        expect(response.headers["ETag"]).to match(/W\/".+"/)
+        expect(response.headers["Cache-Control"]).to eq("max-age=0, private, must-revalidate")
+      end
+
+      context "if browser sends fresh cache headers" do
+        it "returns not modified" do
+          get alchemy_json_api.admin_layout_page_path(page)
+          etag = response.headers["ETag"]
+          get alchemy_json_api.admin_layout_page_path(page),
+              headers: {
+                "If-Modified-Since" => page.updated_at.utc.httpdate,
+                "If-None-Match" => etag,
+              }
+          expect(response.status).to eq(304)
+        end
+      end
     end
   end
 

--- a/spec/requests/alchemy/json_api/layout_pages_spec.rb
+++ b/spec/requests/alchemy/json_api/layout_pages_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Alchemy::JsonApi::LayoutPagesController", type: :request do
     end
 
     context "when the language is incorrect" do
-      let!(:language) { FactoryBot.create(:alchemy_language) }
+      let!(:language) { Alchemy::Language.first || FactoryBot.create(:alchemy_language) }
       let!(:other_language) { FactoryBot.create(:alchemy_language, :german) }
       let(:page) { FactoryBot.create(:alchemy_page, :public, :layoutpage, language: other_language) }
 

--- a/spec/requests/alchemy/json_api/pages_spec.rb
+++ b/spec/requests/alchemy/json_api/pages_spec.rb
@@ -132,9 +132,31 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
     context "with layoutpages and unpublished pages" do
       let!(:layoutpage) { FactoryBot.create(:alchemy_page, :layoutpage, :public) }
       let!(:non_public_page) { FactoryBot.create(:alchemy_page) }
-      let!(:public_page) { FactoryBot.create(:alchemy_page, :public) }
+      let!(:public_page) { FactoryBot.create(:alchemy_page, :public, published_at: Date.yesterday) }
 
       context "as anonymous user" do
+        let!(:pages) { [public_page] }
+
+        it "sets cache headers of latest published page" do
+          get alchemy_json_api.pages_path
+          expect(response.headers["Last-Modified"]).to eq(pages.max_by(&:published_at).published_at.utc.httpdate)
+          expect(response.headers["ETag"]).to match(/W\/".+"/)
+          expect(response.headers["Cache-Control"]).to eq("max-age=0, private, must-revalidate")
+        end
+
+        context "if browser sends fresh cache headers" do
+          it "returns not modified" do
+            get alchemy_json_api.pages_path
+            etag = response.headers["ETag"]
+            get alchemy_json_api.pages_path,
+                headers: {
+                  "If-Modified-Since" => pages.max_by(&:published_at).published_at.utc.httpdate,
+                  "If-None-Match" => etag,
+                }
+            expect(response.status).to eq(304)
+          end
+        end
+
         it "returns public content pages only" do
           get alchemy_json_api.pages_path
           document = JSON.parse(response.body)
@@ -158,6 +180,27 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
           expect(document["data"]).not_to include(have_id(non_public_page.id.to_s))
           expect(document["data"]).to include(have_id(public_page.id.to_s))
         end
+      end
+    end
+
+    context "with filters" do
+      let!(:standard_page) { FactoryBot.create(:alchemy_page, :public, published_at: 2.weeks.ago) }
+      let!(:news_page) { FactoryBot.create(:alchemy_page, :public, page_layout: "news", published_at: 1.week.ago) }
+      let!(:news_page2) { FactoryBot.create(:alchemy_page, :public, page_layout: "news", published_at: Date.yesterday) }
+
+      it "returns only matching pages" do
+        get alchemy_json_api.pages_path(filter: { page_layout_eq: "news" })
+        document = JSON.parse(response.body)
+        expect(document["data"]).not_to include(have_id(standard_page.id.to_s))
+        expect(document["data"]).to include(have_id(news_page.id.to_s))
+        expect(document["data"]).to include(have_id(news_page2.id.to_s))
+      end
+
+      it "sets cache headers of latest matching page" do
+        get alchemy_json_api.pages_path(filter: { page_layout_eq: "news" })
+        expect(response.headers["Last-Modified"]).to eq(news_page2.published_at.utc.httpdate)
+        expect(response.headers["ETag"]).to match(/W\/".+"/)
+        expect(response.headers["Cache-Control"]).to eq("max-age=0, private, must-revalidate")
       end
     end
 


### PR DESCRIPTION
1. Caches the serialization result

Uses the jsonapi-serializer feature for caching that uses the configured Rails cache store.

Never expire the records because page and element records have a cache_key that is updated by alchemy in the correct way.

2. Adds HTTP caching

Uses [conditional get](https://api.rubyonrails.org/v6.1.3.1/classes/ActionController/ConditionalGet.html#method-i-stale-3F) for loading page(s) only when necessary from the database. If the browser cache is still fresh we return a 304 instead.
