### PR TITLE
Add url_path attribute to page serializer

### DIFF
--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -9,6 +9,7 @@ module Alchemy
       attributes(
         :name,
         :urlname,
+        :url_path,
         :page_layout,
         :title,
         :language_code,

--- a/spec/serializers/alchemy/json_api/page_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/page_serializer_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Alchemy::JsonApi::PageSerializer do
     it "has the right keys and values" do
       attributes = subject[:data][:attributes]
       expect(attributes[:urlname]).to eq("a-page")
+      expect(attributes[:url_path]).to eq("/a-page")
       expect(attributes[:name]).to eq(page.name)
       expect(attributes[:page_layout]).to eq("standard")
       expect(attributes[:title]).to eq("Page Title")


### PR DESCRIPTION
The `url_path` is used as the actual link to a page. It contains everything that is necessary to have a canonical link to a page without any redirects, while the `urlname` is just the nested friendly page name without leading or trailing slashes or locales or mount points, etc.

TL;DR this attribute is important and should be used for linking to a page.