### PR TITLE
Do not throw error if filter returns empty result

### DIFF
--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -10,7 +10,7 @@ module Alchemy
 
         jsonapi_filter(page_scope, allowed) do |filtered_pages|
           @pages = filtered_pages.result
-          if stale?(last_modified: @pages.maximum(:published_at), etag: @pages.max_by(&:cache_key).cache_key)
+          if stale?(last_modified: @pages.maximum(:published_at), etag: @pages.max_by(&:cache_key)&.cache_key)
             # Only load pages with all includes when browser cache is stale
             jsonapi_filter(page_scope_with_includes, allowed) do |filtered|
               # decorate with our page model that has a eager loaded elements collection

--- a/spec/requests/alchemy/json_api/pages_spec.rb
+++ b/spec/requests/alchemy/json_api/pages_spec.rb
@@ -228,6 +228,13 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
         expect(document["data"]).to include(have_id(news_page2.id.to_s))
       end
 
+      context "if no pages returned for filter params" do
+        it "does not throw error" do
+          get alchemy_json_api.pages_path(filter: { page_layout_eq: "not-found" })
+          expect(response).to be_successful
+        end
+      end
+
       it "sets cache headers of latest matching page" do
         get alchemy_json_api.pages_path(filter: { page_layout_eq: "news" })
         expect(response.headers["Last-Modified"]).to eq(news_page2.published_at.utc.httpdate)


### PR DESCRIPTION
When a filter results in an empty result set then `max_by` returns `nil`