### PR TITLE
Add srcset support

### DIFF
--- a/app/serializers/alchemy/json_api/essence_picture_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_picture_serializer.rb
@@ -33,6 +33,27 @@ module Alchemy
           }
         end
 
+        attribute :srcset do |essence|
+          essence.content.settings.fetch(:srcset, []).map do |src|
+            case src
+            when Hash
+              url = essence.picture_url(src)
+              size = src[:size]
+            else
+              url = essence.picture_url(size: src)
+              size = src
+            end
+            width, height = size.split("x", 2)
+
+            {
+              url: url,
+              desc: "#{width}w",
+              width: width,
+              height: height,
+            }
+          end
+        end
+
         attribute :image_name do |essence|
           essence.picture.name
         end

--- a/app/serializers/alchemy/json_api/ingredient_picture_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_picture_serializer.rb
@@ -39,6 +39,27 @@ module Alchemy
           }
         end
 
+        attribute :srcset do |ingredient|
+          ingredient.settings.fetch(:srcset, []).map do |src|
+            case src
+            when Hash
+              url = ingredient.picture_url(src)
+              size = src[:size]
+            else
+              url = ingredient.picture_url(size: src)
+              size = src
+            end
+            width, height = size.split("x", 2)
+
+            {
+              url: url,
+              desc: "#{width}w",
+              width: width,
+              height: height,
+            }
+          end
+        end
+
         attribute :image_name do |ingredient|
           ingredient.picture.name
         end

--- a/spec/serializers/alchemy/json_api/ingredient_picture_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/ingredient_picture_serializer_spec.rb
@@ -80,6 +80,85 @@ RSpec.describe Alchemy::JsonApi::IngredientPictureSerializer do
         end
       end
     end
+
+    describe "srcset" do
+      let(:srcset) { subject[:srcset] }
+
+      context "without image" do
+        let(:picture) { nil }
+
+        it { expect(srcset).to be_nil }
+      end
+
+      context "with srcset defined" do
+        before do
+          expect(ingredient).to receive(:settings).at_least(:once) do
+            {
+              srcset: srcset_definition,
+            }
+          end
+        end
+
+        context "as strings" do
+          let(:srcset_definition) do
+            %w[100x100 200x100]
+          end
+
+          it "returns src sets objects" do
+            expect(srcset).to match_array(
+              [
+                {
+                  url: instance_of(String),
+                  desc: "100w",
+                  width: "100",
+                  height: "100",
+                },
+                {
+                  url: instance_of(String),
+                  desc: "200w",
+                  width: "200",
+                  height: "100",
+                },
+              ]
+            )
+          end
+        end
+
+        context "as hash" do
+          let(:srcset_definition) do
+            [
+              {
+                size: "100x100",
+                crop: true,
+              },
+              {
+                size: "200x100",
+                format: "jpg",
+              },
+            ]
+          end
+
+          it "returns src sets objects" do
+            expect(srcset).to match_array(
+              [
+                {
+                  url: instance_of(String),
+                  desc: "100w",
+                  width: "100",
+                  height: "100",
+                },
+                {
+                  url: a_string_matching(%r{.jpg}),
+                  desc: "200w",
+                  width: "200",
+                  height: "100",
+                },
+              ]
+            )
+          end
+        end
+      end
+    end
   end
 
   context "With no picture set" do


### PR DESCRIPTION
`srcset` is a powerful tool for providing responsive images. Alchemy has support for it on the HTML side of things for a very long time. Let's get this into the JAMStack age.

If `srcset` is defined on the element definition, then it returns an array of image candidates its descriptor and the image dimensions.

eg:

```json
{
  "url": "cute-kittins.jpg",
  "desc": "200w",
  "width": "200",
  "height": "100",
}
```

You can define `srcset` candidates either as a size `String` or a `Hash` supporting **all image transformations** Alchemy supports. So you are able to create cropped JPGs from a PNG for instance by doing this:

```yml
- name: Hero
  contents:
    - name: image
      type: EssencePicture
      settings:
        size: 1920x700
        srcset:
          - size: 200x200
            crop: true
            quality: 60
            format: jpg
          - 860x350
```