### PR TITLE
Add support for disabled cache per page

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,8 @@ else
   require "alchemy/test_support/factories"
 end
 
+require "alchemy/test_support/config_stubbing"
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -81,4 +83,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include Alchemy::TestSupport::ConfigStubbing
 end

--- a/spec/requests/alchemy/json_api/admin/layout_pages_spec.rb
+++ b/spec/requests/alchemy/json_api/admin/layout_pages_spec.rb
@@ -103,23 +103,30 @@ RSpec.describe "Alchemy::JsonApi::Admin::LayoutPagesController", type: :request 
         )
       end
 
-      it "sets cache headers" do
-        get alchemy_json_api.admin_layout_page_path(page)
-        expect(response.headers["Last-Modified"]).to eq(page.updated_at.utc.httpdate)
-        expect(response.headers["ETag"]).to match(/W\/".+"/)
-        expect(response.headers["Cache-Control"]).to eq("max-age=0, private, must-revalidate")
-      end
+      context "with caching enabled" do
+        before do
+          allow(Rails.application.config.action_controller).to receive(:perform_caching) { true }
+          stub_alchemy_config(:cache_pages, true)
+        end
 
-      context "if browser sends fresh cache headers" do
-        it "returns not modified" do
+        it "sets cache headers" do
           get alchemy_json_api.admin_layout_page_path(page)
-          etag = response.headers["ETag"]
-          get alchemy_json_api.admin_layout_page_path(page),
-              headers: {
-                "If-Modified-Since" => page.updated_at.utc.httpdate,
-                "If-None-Match" => etag,
-              }
-          expect(response.status).to eq(304)
+          expect(response.headers["Last-Modified"]).to eq(page.updated_at.utc.httpdate)
+          expect(response.headers["ETag"]).to match(/W\/".+"/)
+          expect(response.headers["Cache-Control"]).to eq("max-age=0, private, must-revalidate")
+        end
+
+        context "if browser sends fresh cache headers" do
+          it "returns not modified" do
+            get alchemy_json_api.admin_layout_page_path(page)
+            etag = response.headers["ETag"]
+            get alchemy_json_api.admin_layout_page_path(page),
+                headers: {
+                  "If-Modified-Since" => page.updated_at.utc.httpdate,
+                  "If-None-Match" => etag,
+                }
+            expect(response.status).to eq(304)
+          end
         end
       end
     end

--- a/spec/requests/alchemy/json_api/admin/pages_spec.rb
+++ b/spec/requests/alchemy/json_api/admin/pages_spec.rb
@@ -26,23 +26,30 @@ RSpec.describe "Alchemy::JsonApi::Admin::PagesController", type: :request do
 
       let(:document) { JSON.parse(response.body) }
 
-      it "sets cache headers" do
-        get alchemy_json_api.admin_page_path(page)
-        expect(response.headers["Last-Modified"]).to eq(page.updated_at.utc.httpdate)
-        expect(response.headers["ETag"]).to match(/W\/".+"/)
-        expect(response.headers["Cache-Control"]).to eq("max-age=0, private, must-revalidate")
-      end
+      context "with caching enabled" do
+        before do
+          allow(Rails.application.config.action_controller).to receive(:perform_caching) { true }
+          stub_alchemy_config(:cache_pages, true)
+        end
 
-      context "if browser sends fresh cache headers" do
-        it "returns not modified" do
+        it "sets cache headers" do
           get alchemy_json_api.admin_page_path(page)
-          etag = response.headers["ETag"]
-          get alchemy_json_api.admin_page_path(page),
-              headers: {
-                "If-Modified-Since" => page.updated_at.utc.httpdate,
-                "If-None-Match" => etag,
-              }
-          expect(response.status).to eq(304)
+          expect(response.headers["Last-Modified"]).to eq(page.updated_at.utc.httpdate)
+          expect(response.headers["ETag"]).to match(/W\/".+"/)
+          expect(response.headers["Cache-Control"]).to eq("max-age=0, private, must-revalidate")
+        end
+
+        context "if browser sends fresh cache headers" do
+          it "returns not modified" do
+            get alchemy_json_api.admin_page_path(page)
+            etag = response.headers["ETag"]
+            get alchemy_json_api.admin_page_path(page),
+                headers: {
+                  "If-Modified-Since" => page.updated_at.utc.httpdate,
+                  "If-None-Match" => etag,
+                }
+            expect(response.status).to eq(304)
+          end
         end
       end
 


### PR DESCRIPTION
A page can have caching disabled via the `cache: false` flag on a pages `page_layout` definition.