### PR TITLE
Add a session store to dummy app

### DIFF
--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -25,10 +25,5 @@ module Dummy
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
-
-    # Only loads a smaller set of middleware suitable for API only apps.
-    # Middleware like session, flash, cookies can be added back manually.
-    # Skip views, helpers and assets when generating a new resource.
-    config.api_only = true
   end
 end

--- a/spec/dummy/config/initializers/session_store.rb
+++ b/spec/dummy/config/initializers/session_store.rb
@@ -1,0 +1,3 @@
+# Be sure to restart your server when you modify this file.
+
+Rails.application.config.session_store :cookie_store, key: '_dummy_session'


### PR DESCRIPTION
Alchemy requires a session store. Rails 7 now raises an error if
an app has no session store configured. Removes the api_only
from the dummy app, so it loads the session.