### PR TITLE
Allow key transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ const pages = deserializePages(data)
 console.log(pages[0].name) // => Homepage
 ```
 
+## Key transforms
+
+If you ever want to change how Alchemy serializes attributes you can set
+
+```rb
+Alchemy::JsonApi.key_transform = :camel_lower
+```
+
+It defaults to `:underscore`.
+
 ## Contributing
 Contribution directions go here.
 

--- a/app/serializers/alchemy/json_api/base_serializer.rb
+++ b/app/serializers/alchemy/json_api/base_serializer.rb
@@ -1,0 +1,7 @@
+module Alchemy
+  module JsonApi
+    class BaseSerializer
+      include JSONAPI::Serializer
+    end
+  end
+end

--- a/app/serializers/alchemy/json_api/base_serializer.rb
+++ b/app/serializers/alchemy/json_api/base_serializer.rb
@@ -2,6 +2,8 @@ module Alchemy
   module JsonApi
     class BaseSerializer
       include JSONAPI::Serializer
+
+      set_key_transform Alchemy::JsonApi.key_transform
     end
   end
 end

--- a/app/serializers/alchemy/json_api/element_serializer.rb
+++ b/app/serializers/alchemy/json_api/element_serializer.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 module Alchemy
   module JsonApi
-    class ElementSerializer
-      include JSONAPI::Serializer
-
+    class ElementSerializer < BaseSerializer
       attributes(
         :name,
         :fixed,

--- a/app/serializers/alchemy/json_api/essence_audio_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_audio_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/essence_serializer"
 
 module Alchemy
   module JsonApi
-    class EssenceAudioSerializer
+    class EssenceAudioSerializer < BaseSerializer
       include EssenceSerializer
 
       attributes(

--- a/app/serializers/alchemy/json_api/essence_boolean_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_boolean_serializer.rb
@@ -3,7 +3,7 @@ require "alchemy/json_api/essence_serializer"
 
 module Alchemy
   module JsonApi
-    class EssenceBooleanSerializer
+    class EssenceBooleanSerializer < BaseSerializer
       include EssenceSerializer
     end
   end

--- a/app/serializers/alchemy/json_api/essence_date_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_date_serializer.rb
@@ -3,7 +3,7 @@ require "alchemy/json_api/essence_serializer"
 
 module Alchemy
   module JsonApi
-    class EssenceDateSerializer
+    class EssenceDateSerializer < BaseSerializer
       include EssenceSerializer
     end
   end

--- a/app/serializers/alchemy/json_api/essence_file_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_file_serializer.rb
@@ -3,7 +3,7 @@ require "alchemy/json_api/essence_serializer"
 
 module Alchemy
   module JsonApi
-    class EssenceFileSerializer
+    class EssenceFileSerializer < BaseSerializer
       include EssenceSerializer
 
       attribute :link_title, &:title

--- a/app/serializers/alchemy/json_api/essence_headline_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_headline_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/essence_serializer"
 
 module Alchemy
   module JsonApi
-    class EssenceHeadlineSerializer
+    class EssenceHeadlineSerializer < BaseSerializer
       include EssenceSerializer
 
       attributes :level, :size

--- a/app/serializers/alchemy/json_api/essence_html_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_html_serializer.rb
@@ -3,7 +3,7 @@ require "alchemy/json_api/essence_serializer"
 
 module Alchemy
   module JsonApi
-    class EssenceHtmlSerializer
+    class EssenceHtmlSerializer < BaseSerializer
       include EssenceSerializer
     end
   end

--- a/app/serializers/alchemy/json_api/essence_link_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_link_serializer.rb
@@ -3,7 +3,7 @@ require "alchemy/json_api/essence_serializer"
 
 module Alchemy
   module JsonApi
-    class EssenceLinkSerializer
+    class EssenceLinkSerializer < BaseSerializer
       include EssenceSerializer
       attributes(
         :link_title,

--- a/app/serializers/alchemy/json_api/essence_node_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_node_serializer.rb
@@ -3,7 +3,7 @@ require "alchemy/json_api/essence_serializer"
 
 module Alchemy
   module JsonApi
-    class EssenceNodeSerializer
+    class EssenceNodeSerializer < BaseSerializer
       include EssenceSerializer
 
       attribute :ingredient do |essence|

--- a/app/serializers/alchemy/json_api/essence_page_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_page_serializer.rb
@@ -3,7 +3,7 @@ require "alchemy/json_api/essence_serializer"
 
 module Alchemy
   module JsonApi
-    class EssencePageSerializer
+    class EssencePageSerializer < BaseSerializer
       include EssenceSerializer
 
       attribute :ingredient do |essence|

--- a/app/serializers/alchemy/json_api/essence_picture_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_picture_serializer.rb
@@ -3,7 +3,7 @@ require "alchemy/json_api/essence_serializer"
 
 module Alchemy
   module JsonApi
-    class EssencePictureSerializer
+    class EssencePictureSerializer < BaseSerializer
       include EssenceSerializer
 
       attributes(

--- a/app/serializers/alchemy/json_api/essence_richtext_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_richtext_serializer.rb
@@ -3,7 +3,7 @@ require "alchemy/json_api/essence_serializer"
 
 module Alchemy
   module JsonApi
-    class EssenceRichtextSerializer
+    class EssenceRichtextSerializer < BaseSerializer
       include EssenceSerializer
       attributes(
         :body,

--- a/app/serializers/alchemy/json_api/essence_select_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_select_serializer.rb
@@ -3,7 +3,7 @@ require "alchemy/json_api/essence_serializer"
 
 module Alchemy
   module JsonApi
-    class EssenceSelectSerializer
+    class EssenceSelectSerializer < BaseSerializer
       include EssenceSerializer
     end
   end

--- a/app/serializers/alchemy/json_api/essence_text_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_text_serializer.rb
@@ -3,7 +3,7 @@ require "alchemy/json_api/essence_serializer"
 
 module Alchemy
   module JsonApi
-    class EssenceTextSerializer
+    class EssenceTextSerializer < BaseSerializer
       include EssenceSerializer
       attributes(
         :body,

--- a/app/serializers/alchemy/json_api/essence_video_serializer.rb
+++ b/app/serializers/alchemy/json_api/essence_video_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/essence_serializer"
 
 module Alchemy
   module JsonApi
-    class EssenceVideoSerializer
+    class EssenceVideoSerializer < BaseSerializer
       include EssenceSerializer
 
       attributes(

--- a/app/serializers/alchemy/json_api/ingredient_audio_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_audio_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/ingredient_serializer"
 
 module Alchemy
   module JsonApi
-    class IngredientAudioSerializer
+    class IngredientAudioSerializer < BaseSerializer
       include IngredientSerializer
 
       attributes(

--- a/app/serializers/alchemy/json_api/ingredient_boolean_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_boolean_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/ingredient_serializer"
 
 module Alchemy
   module JsonApi
-    class IngredientBooleanSerializer
+    class IngredientBooleanSerializer < BaseSerializer
       include IngredientSerializer
     end
   end

--- a/app/serializers/alchemy/json_api/ingredient_datetime_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_datetime_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/ingredient_serializer"
 
 module Alchemy
   module JsonApi
-    class IngredientDatetimeSerializer
+    class IngredientDatetimeSerializer < BaseSerializer
       include IngredientSerializer
     end
   end

--- a/app/serializers/alchemy/json_api/ingredient_file_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_file_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/ingredient_serializer"
 
 module Alchemy
   module JsonApi
-    class IngredientFileSerializer
+    class IngredientFileSerializer < BaseSerializer
       include IngredientSerializer
 
       attribute :link_title, &:title

--- a/app/serializers/alchemy/json_api/ingredient_headline_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_headline_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/ingredient_serializer"
 
 module Alchemy
   module JsonApi
-    class IngredientHeadlineSerializer
+    class IngredientHeadlineSerializer < BaseSerializer
       include IngredientSerializer
 
       attributes :level, :size

--- a/app/serializers/alchemy/json_api/ingredient_html_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_html_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/ingredient_serializer"
 
 module Alchemy
   module JsonApi
-    class IngredientHtmlSerializer
+    class IngredientHtmlSerializer < BaseSerializer
       include IngredientSerializer
     end
   end

--- a/app/serializers/alchemy/json_api/ingredient_link_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_link_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/ingredient_serializer"
 
 module Alchemy
   module JsonApi
-    class IngredientLinkSerializer
+    class IngredientLinkSerializer < BaseSerializer
       include IngredientSerializer
 
       attributes(

--- a/app/serializers/alchemy/json_api/ingredient_node_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_node_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/ingredient_serializer"
 
 module Alchemy
   module JsonApi
-    class IngredientNodeSerializer
+    class IngredientNodeSerializer < BaseSerializer
       include IngredientSerializer
 
       attribute :value do |ingredient|

--- a/app/serializers/alchemy/json_api/ingredient_page_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_page_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/ingredient_serializer"
 
 module Alchemy
   module JsonApi
-    class IngredientPageSerializer
+    class IngredientPageSerializer < BaseSerializer
       include IngredientSerializer
 
       attribute :value do |ingredient|

--- a/app/serializers/alchemy/json_api/ingredient_picture_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_picture_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/ingredient_serializer"
 
 module Alchemy
   module JsonApi
-    class IngredientPictureSerializer
+    class IngredientPictureSerializer < BaseSerializer
       include IngredientSerializer
 
       attributes(

--- a/app/serializers/alchemy/json_api/ingredient_richtext_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_richtext_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/ingredient_serializer"
 
 module Alchemy
   module JsonApi
-    class IngredientRichtextSerializer
+    class IngredientRichtextSerializer < BaseSerializer
       include IngredientSerializer
 
       attributes(

--- a/app/serializers/alchemy/json_api/ingredient_select_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_select_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/ingredient_serializer"
 
 module Alchemy
   module JsonApi
-    class IngredientSelectSerializer
+    class IngredientSelectSerializer < BaseSerializer
       include IngredientSerializer
     end
   end

--- a/app/serializers/alchemy/json_api/ingredient_text_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_text_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/ingredient_serializer"
 
 module Alchemy
   module JsonApi
-    class IngredientTextSerializer
+    class IngredientTextSerializer < BaseSerializer
       include IngredientSerializer
 
       attributes(

--- a/app/serializers/alchemy/json_api/ingredient_video_serializer.rb
+++ b/app/serializers/alchemy/json_api/ingredient_video_serializer.rb
@@ -4,7 +4,7 @@ require "alchemy/json_api/ingredient_serializer"
 
 module Alchemy
   module JsonApi
-    class IngredientVideoSerializer
+    class IngredientVideoSerializer < BaseSerializer
       include IngredientSerializer
 
       attributes(

--- a/app/serializers/alchemy/json_api/language_serializer.rb
+++ b/app/serializers/alchemy/json_api/language_serializer.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 module Alchemy
   module JsonApi
-    class LanguageSerializer
-      include JSONAPI::Serializer
-
+    class LanguageSerializer < BaseSerializer
       attributes(
         :name,
         :language_code,

--- a/app/serializers/alchemy/json_api/node_serializer.rb
+++ b/app/serializers/alchemy/json_api/node_serializer.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 module Alchemy
   module JsonApi
-    class NodeSerializer
-      include JSONAPI::Serializer
-
+    class NodeSerializer < BaseSerializer
       attributes :name
       attribute :link_url, &:url
       attribute :link_title, &:title

--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 module Alchemy
   module JsonApi
-    class PageSerializer
-      include JSONAPI::Serializer
-
+    class PageSerializer < BaseSerializer
       ELEMENT_SERIALIZER = ::Alchemy::JsonApi::ElementSerializer
 
       attributes(

--- a/lib/alchemy/json_api.rb
+++ b/lib/alchemy/json_api.rb
@@ -1,10 +1,28 @@
 # frozen_string_literal: true
+
 require "fast_jsonapi"
 require "alchemy_cms"
 require "alchemy/json_api/engine"
 
 module Alchemy
   module JsonApi
-    # Your code goes here...
+    # Set FastJsonapi key_transform
+    #
+    # Supported transformations:
+    #
+    # :camel # "some_key" => "SomeKey"
+    # :camel_lower # "some_key" => "someKey"
+    # :dash # "some_key" => "some-key"
+    # :underscore # "some_key" => "some_key"
+    def self.key_transform=(value)
+      @_key_transform = value
+    end
+
+    # FastJsonapi key_transform
+    #
+    # Default :underscore # "some_key" => "some_key"
+    def self.key_transform
+      @_key_transform || :underscore
+    end
   end
 end

--- a/lib/alchemy/json_api/essence_serializer.rb
+++ b/lib/alchemy/json_api/essence_serializer.rb
@@ -3,7 +3,6 @@ module Alchemy
   module JsonApi
     module EssenceSerializer
       def self.included(klass)
-        klass.include JSONAPI::Serializer
         klass.has_one :element, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer do |essence|
           essence.content.element
         end

--- a/lib/alchemy/json_api/ingredient_serializer.rb
+++ b/lib/alchemy/json_api/ingredient_serializer.rb
@@ -4,8 +4,6 @@ module Alchemy
   module JsonApi
     module IngredientSerializer
       def self.included(klass)
-        klass.include JSONAPI::Serializer
-
         klass.has_one :element, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer
 
         klass.attributes(

--- a/lib/alchemy/json_api/test_support/ingredient_serializer_behaviour.rb
+++ b/lib/alchemy/json_api/test_support/ingredient_serializer_behaviour.rb
@@ -4,11 +4,15 @@ RSpec.shared_examples "an ingredient serializer" do
   describe "attributes" do
     subject { serializer.serializable_hash[:data][:attributes] }
 
-    it "has the right keys and values" do
+    it "has the right transformed keys and values" do
+      transform_method = FastJsonapi::ObjectSerializer::TRANSFORMS_MAPPING[Alchemy::JsonApi.key_transform]
+      transformed_keys = %w[created_at updated_at].map { |k| k.send(*transform_method).to_sym }
+
       expect(subject).to have_key(:role)
       expect(subject).to have_key(:value)
-      expect(subject).to have_key(:created_at)
-      expect(subject).to have_key(:updated_at)
+      transformed_keys.each do |transformed_key|
+        expect(subject).to have_key(transformed_key)
+      end
       expect(subject[:deprecated]).to be(false)
     end
 

--- a/spec/serializers/alchemy/json_api/base_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/base_serializer_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::JsonApi::BaseSerializer do
+  it { expect(described_class).to be < JSONAPI::Serializer }
+
+  it "sets key_transform" do
+    expect(described_class).to receive(:set_key_transform).with(:underscore)
+    load Alchemy::JsonApi::Engine.root.join("app/serializers/alchemy/json_api/base_serializer.rb")
+  end
+end


### PR DESCRIPTION
If you ever want to change how Alchemy serializes attributes you can set

```rb
Alchemy::JsonApi.key_transform = :camel_lower
```

It defaults to `:underscore`.