### PR TITLE
Fix page search

### DIFF
--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -6,7 +6,7 @@ module Alchemy
       before_action :load_page_for_cache_key, only: :show
 
       def index
-        allowed = [:page_layout, :urlname]
+        allowed = Alchemy::Page.ransackable_attributes
 
         jsonapi_filter(page_scope, allowed) do |filtered_pages|
           @pages = filtered_pages.result
@@ -79,6 +79,7 @@ module Alchemy
 
       def load_page_by_id
         return unless params[:path] =~ /\A\d+\z/
+
         page_scope_with_includes.find_by(id: params[:path])
       end
 
@@ -104,7 +105,7 @@ module Alchemy
                   ],
                 },
               },
-            ]
+            ],
           )
       end
 

--- a/app/models/alchemy/json_api/page.rb
+++ b/app/models/alchemy/json_api/page.rb
@@ -2,7 +2,7 @@ module Alchemy
   # With Ransack 4 we need to define the attributes
   # that are allowed to be searched.
   def Page.ransackable_attributes(_auth_object = nil)
-    %w[urlname page_layout]
+    super | %w[page_layout]
   end
 
   module JsonApi

--- a/spec/requests/alchemy/json_api/pages_spec.rb
+++ b/spec/requests/alchemy/json_api/pages_spec.rb
@@ -264,13 +264,21 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
     context "with filters" do
       let!(:standard_page) { FactoryBot.create(:alchemy_page, :public, published_at: 2.weeks.ago) }
       let!(:news_page) { FactoryBot.create(:alchemy_page, :public, page_layout: "news", published_at: 1.week.ago) }
-      let!(:news_page2) { FactoryBot.create(:alchemy_page, :public, page_layout: "news", published_at: Date.yesterday) }
+      let!(:news_page2) { FactoryBot.create(:alchemy_page, :public, name: "News", page_layout: "news", published_at: Date.yesterday) }
 
-      it "returns only matching pages" do
+      it "returns only matching pages by page_layout" do
         get alchemy_json_api.pages_path(filter: { page_layout_eq: "news" })
         document = JSON.parse(response.body)
         expect(document["data"]).not_to include(have_id(standard_page.id.to_s))
         expect(document["data"]).to include(have_id(news_page.id.to_s))
+        expect(document["data"]).to include(have_id(news_page2.id.to_s))
+      end
+
+      it "returns only matching pages by name" do
+        get alchemy_json_api.pages_path(filter: { name_eq: "News" })
+        document = JSON.parse(response.body)
+        expect(document["data"]).not_to include(have_id(standard_page.id.to_s))
+        expect(document["data"]).not_to include(have_id(news_page.id.to_s))
         expect(document["data"]).to include(have_id(news_page2.id.to_s))
       end
 


### PR DESCRIPTION
We overwrote `ransackable_attributes` to only include `page_layout` and `urlname`, 
but Alchemy needs `name` as well. 

Fixed by adding `page_layout` to already defined `ransackable_attributes`.