### PR TITLE
Expose public_on date

### DIFF
--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -13,6 +13,7 @@ module Alchemy
         :language_code,
         :meta_keywords,
         :meta_description,
+        :public_on,
         :created_at,
         :updated_at,
       )

--- a/spec/serializers/alchemy/json_api/page_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/page_serializer_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Alchemy::JsonApi::PageSerializer do
       expect(attributes[:language_code]).to eq("en")
       expect(attributes[:meta_keywords]).to eq("Meta Keywords")
       expect(attributes[:meta_description]).to eq("Meta Description")
+      expect(attributes[:public_on]).to eq(page.public_on)
       expect(attributes[:created_at]).to eq(page.created_at)
       expect(attributes[:updated_at]).to eq(page.updated_at)
       expect(attributes[:legacy_urls]).to eq(["/other"])


### PR DESCRIPTION
This PR exposes the Page's public_on attribute via the api.