### PR TITLE
Allow jsonapi.rb 2.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ RSpec::Core::RakeTask.new(:spec)
 
 task default: [:test_setup, :spec]
 
+require "active_support"
 require "active_support/core_ext/string"
 
 desc "Setup test app"

--- a/alchemy-json_api.gemspec
+++ b/alchemy-json_api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "alchemy_cms", [">= 7.0.0.a", "< 8"]
-  spec.add_dependency "jsonapi.rb", "~> 1.6"
+  spec.add_dependency "jsonapi.rb", [">= 1.6.0", "< 2.1"]
 
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "github_changelog_generator"


### PR DESCRIPTION
In 2022, they released a new version of jsonapi.rb. The functionality almost did not change at all, so no changes on our side are necessary.