### PR TITLE
Improve etag generation

### DIFF
--- a/app/controllers/alchemy/json_api/admin/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/admin/pages_controller.rb
@@ -25,7 +25,7 @@ module Alchemy
           end
         end
 
-        def last_modified_for(page)
+        def page_cache_key(page)
           page.updated_at
         end
 

--- a/spec/requests/alchemy/json_api/admin/layout_pages_spec.rb
+++ b/spec/requests/alchemy/json_api/admin/layout_pages_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "Alchemy::JsonApi::Admin::LayoutPagesController", type: :request 
 
         it "sets cache headers" do
           get alchemy_json_api.admin_layout_page_path(page)
-          expect(response.headers["Last-Modified"]).to eq(page.updated_at.utc.httpdate)
+          expect(response.headers["Last-Modified"]).to be nil
           expect(response.headers["ETag"]).to match(/W\/".+"/)
           expect(response.headers["Cache-Control"]).to eq("max-age=0, private, must-revalidate")
         end

--- a/spec/requests/alchemy/json_api/admin/pages_spec.rb
+++ b/spec/requests/alchemy/json_api/admin/pages_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Alchemy::JsonApi::Admin::PagesController", type: :request do
 
         it "sets cache headers" do
           get alchemy_json_api.admin_page_path(page)
-          expect(response.headers["Last-Modified"]).to eq(page.updated_at.utc.httpdate)
+          expect(response.headers["Last-Modified"]).to be(nil)
           expect(response.headers["ETag"]).to match(/W\/".+"/)
           expect(response.headers["Cache-Control"]).to eq("max-age=0, private, must-revalidate")
         end


### PR DESCRIPTION
The Last-Modified header is a weaker cache key than the etag, and thus
we rely solely on the etag from now on. Browsers and Rails will ignore
it if it's not set while validating if a request is fresh.
