### PR TITLE
Do not convert cache duration to hours

### DIFF
--- a/app/controllers/alchemy/json_api/nodes_controller.rb
+++ b/app/controllers/alchemy/json_api/nodes_controller.rb
@@ -3,6 +3,8 @@
 module Alchemy
   module JsonApi
     class NodesController < JsonApi::BaseController
+      THREE_HOURS = 10800
+
       def index
         @nodes = node_scope.select(:id, :updated_at)
         if stale?(last_modified: @nodes.maximum(:updated_at), etag: @nodes)
@@ -17,7 +19,7 @@ module Alchemy
       private
 
       def cache_duration
-        ENV.fetch("ALCHEMY_JSON_API_CACHE_DURATION", 3).to_i.hours
+        ENV.fetch("ALCHEMY_JSON_API_CACHE_DURATION", THREE_HOURS).to_i
       end
 
       def jsonapi_meta(nodes)

--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -3,6 +3,8 @@
 module Alchemy
   module JsonApi
     class PagesController < JsonApi::BaseController
+      THREE_HOURS = 10800
+
       before_action :load_page_for_cache_key, only: :show
 
       def index
@@ -47,7 +49,7 @@ module Alchemy
       end
 
       def cache_duration
-        ENV.fetch("ALCHEMY_JSON_API_CACHE_DURATION", 3).to_i.hours
+        ENV.fetch("ALCHEMY_JSON_API_CACHE_DURATION", THREE_HOURS).to_i
       end
 
       def caching_options


### PR DESCRIPTION
Hours is not fine enough as granularity for good cache control. For this reason, the `Cache-Control` header operates with a granularity of seconds as well. Let's also work with seconds here.

This is literally a breaking change, but it will only break caches.