### PR TITLE
Add restricted value to page serializer

### DIFF
--- a/app/serializers/alchemy/json_api/page_serializer.rb
+++ b/app/serializers/alchemy/json_api/page_serializer.rb
@@ -15,7 +15,8 @@ module Alchemy
         :meta_keywords,
         :meta_description,
         :created_at,
-        :updated_at
+        :updated_at,
+        :restricted
       )
 
       cache_options store: Rails.cache, namespace: "alchemy-jsonapi"

--- a/spec/serializers/alchemy/json_api/page_serializer_spec.rb
+++ b/spec/serializers/alchemy/json_api/page_serializer_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Alchemy::JsonApi::PageSerializer do
       expect(attributes[:created_at]).to eq(page.created_at)
       expect(attributes[:updated_at]).to eq(page.updated_at)
       expect(attributes[:legacy_urls]).to eq(["/other"])
+      expect(attributes[:restricted]).to be false
       expect(attributes.keys).not_to include(:tag_list, :status)
     end
   end


### PR DESCRIPTION
This page value is not currently included. Adding it will allow consumers of the api to restrict pages.