### PR TITLE
Fix type error when response is missing `included`

### DIFF
--- a/dist/alchemy-json_api.js
+++ b/dist/alchemy-json_api.js
@@ -11,7 +11,7 @@ var structuredClone__default = /*#__PURE__*/_interopDefaultLegacy(structuredClon
 function deserialize(originalResponse) {
   var response = structuredClone__default["default"](originalResponse);
 
-  var included = response.included || [];
+  var included = response?.included || [];
 
   if (Array.isArray(response.data)) {
     return response.data.map(function (data) {

--- a/src/deserialize.js
+++ b/src/deserialize.js
@@ -6,7 +6,7 @@ export function deserialize(originalResponse, options = {}) {
     options = {}
   }
 
-  const included = response.included || []
+  const included = response?.included || []
 
   if (Array.isArray(response.data)) {
     return response.data.map((data) => {


### PR DESCRIPTION
This fixes the following error when the response from the server does not have the `included` key:

```
TypeError: Cannot read properties of undefined (reading 'included')
```

When missing, the value already defaults to an empty array so this should be safe when it's "undefined" as well.