### PR TITLE
Remove element from IngredientSerializer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         alchemy_branch:
           - 7.0-stable
           - 7.1-stable
+          - 7.2-stable
           - main
         ruby:
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"

--- a/lib/alchemy/json_api/ingredient_serializer.rb
+++ b/lib/alchemy/json_api/ingredient_serializer.rb
@@ -4,8 +4,6 @@ module Alchemy
   module JsonApi
     module IngredientSerializer
       def self.included(klass)
-        klass.has_one :element, record_type: :element, serializer: ::Alchemy::JsonApi::ElementSerializer
-
         klass.attributes(
           :role,
           :value,

--- a/lib/alchemy/json_api/test_support/ingredient_serializer_behaviour.rb
+++ b/lib/alchemy/json_api/test_support/ingredient_serializer_behaviour.rb
@@ -26,12 +26,4 @@ RSpec.shared_examples "an ingredient serializer" do
       end
     end
   end
-
-  describe "relationships" do
-    subject { serializer.serializable_hash[:data][:relationships] }
-
-    it "has one element" do
-      expect(subject[:element]).to eq(data: {id: ingredient.element_id.to_s, type: :element})
-    end
-  end
 end


### PR DESCRIPTION
This association causes infinite recursion during
deserialization, because the element is already
included in the page's elements association's data.