### PR TITLE
Allow jsonapi.rb v2.1

### DIFF
--- a/alchemy-json_api.gemspec
+++ b/alchemy-json_api.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "alchemy_cms", [">= 7.0.0.a", "< 8"]
-  spec.add_dependency "jsonapi.rb", [">= 1.6.0", "< 2.1"]
+  spec.add_dependency "jsonapi.rb", [">= 1.6.0", "< 2.2"]
 
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "github_changelog_generator"


### PR DESCRIPTION
Allows jsonapi.rb to upgrade to 2.1.1. In this version they introduce code to the error serializer. This would be useful to be more semantic about errors.

Changes between versions:
https://my.diffend.io/gems/jsonapi.rb/2.0.1/2.1.1