### PR TITLE
chore: switch from jest to vitest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,6 @@ updates:
         patterns:
           - "@babel/core"
           - "@babel/preset-env"
-      jest:
+      vitest:
         patterns:
-          - "jest"
-          - "babel-jest"
+          - "vitest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           DB_USER: user
           DB_PASSWORD: password
         run: bundle exec rake
-  Jest:
+  Vitest:
     runs-on: ubuntu-24.04
     env:
       NODE_ENV: test
@@ -74,5 +74,5 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install yarn
         run: yarn install
-      - name: Run jest
-        run: yarn jest
+      - name: Run Vitest
+        run: yarn vitest

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,9 +1,0 @@
-{
-  "moduleFileExtensions": ["js"],
-  "transform": {
-    "^.+\\.js$": "babel-jest"
-  },
-  "roots": [
-    "src"
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -26,18 +26,17 @@
     "@ungap/structured-clone": "^1.0.1"
   },
   "devDependencies": {
+    "vitest": "^3.2.4",
     "@babel/core": "^7.19.0",
     "@babel/preset-env": "^7.19.0",
     "@rollup/plugin-babel": "^6.0.4",
-    "babel-jest": "^29.0.2",
-    "jest": "^29.0.2",
     "prettier": "^3.3.3",
     "rollup": "^4.24.4"
   },
   "scripts": {
     "build": "rollup --config",
     "lint": "prettier --check 'src/**/*.js'",
-    "test": "jest"
+    "test": "vitest"
   },
   "browserslist": "> 0.25%, not dead"
 }

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    globals: true
+  }
+})


### PR DESCRIPTION
In order to pave the way to beautiful world of typescript we replace jest with vitest

validate everything is working correctly by running the test script with your favorite package manager