### PR TITLE
Efficient edge caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ const pages = deserializePages(data)
 console.log(pages[0].name) // => Homepage
 ```
 
+## HTTP Caching
+
+Alchemy::JsonApi allows for caching API responses. It respects the caching configuration of your Rails app and of your Alchemy configuration and settings in the pages page layout configuration. Restricted pages are never cached.
+
+By default it sets the `max-age` `Cache-Control` header to 10 minutes (`600` seconds). You can change this by setting the `ALCHEMY_JSON_API_CACHE_DURATION` environment variable.
+
+### Edge Caching
+
+Alchemy sets the `must-revalidate` directive if caching is enabled. If your CDN supports it, you can change that to use the much more efficient `stale-while-revalidate` directive by setting the `ALCHEMY_JSON_API_STALE_WHILE_REVALIDATE` environment variable to any integer value.
+
 ## Key transforms
 
 If you ever want to change how Alchemy serializes attributes you can set

--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -55,7 +55,15 @@ module Alchemy
       end
 
       def caching_options
-        {must_revalidate: true}
+        if ENV["ALCHEMY_JSON_API_CACHE_STALE_WHILE_REVALIDATE"]
+          {
+            stale_while_revalidate: ENV["ALCHEMY_JSON_API_CACHE_STALE_WHILE_REVALIDATE"].to_i
+          }
+        else
+          {
+            must_revalidate: true
+          }
+        end
       end
 
       # Get page w/o includes to get cache key

--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -3,7 +3,7 @@
 module Alchemy
   module JsonApi
     class PagesController < JsonApi::BaseController
-      THREE_HOURS = 10800
+      CACHE_DURATION = 600
       JSONAPI_STALEMAKERS = %i[include fields sort filter page]
 
       before_action :load_page_for_cache_key, only: :show
@@ -51,7 +51,7 @@ module Alchemy
       end
 
       def cache_duration
-        ENV.fetch("ALCHEMY_JSON_API_CACHE_DURATION", THREE_HOURS).to_i
+        ENV.fetch("ALCHEMY_JSON_API_CACHE_DURATION", CACHE_DURATION).to_i
       end
 
       def caching_options

--- a/spec/requests/alchemy/json_api/pages_spec.rb
+++ b/spec/requests/alchemy/json_api/pages_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
           get alchemy_json_api.page_path(page)
           first_etag = response.headers["Last-Modified"]
           expect(response.headers["ETag"]).to match(/W\/".+"/)
-          expect(response.headers["Cache-Control"]).to eq("max-age=10800, public, must-revalidate")
+          expect(response.headers["Cache-Control"]).to eq("max-age=600, public, must-revalidate")
           get alchemy_json_api.page_path(page)
           expect(response.headers["Last-Modified"]).to eq(first_etag)
         end
@@ -60,7 +60,7 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
         it "can set stale-while-revalidate header via ENV variable" do
           ENV["ALCHEMY_JSON_API_CACHE_STALE_WHILE_REVALIDATE"] = "60"
           get alchemy_json_api.page_path(page)
-          expect(response.headers["Cache-Control"]).to eq("max-age=10800, public, stale-while-revalidate=60")
+          expect(response.headers["Cache-Control"]).to eq("max-age=600, public, stale-while-revalidate=60")
           ENV["ALCHEMY_JSON_API_CACHE_STALE_WHILE_REVALIDATE"] = nil
         end
 
@@ -97,7 +97,7 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
 
           it "sets private cache headers" do
             get alchemy_json_api.page_path(page)
-            expect(response.headers["Cache-Control"]).to eq("max-age=10800, private, must-revalidate")
+            expect(response.headers["Cache-Control"]).to eq("max-age=600, private, must-revalidate")
           end
         end
 
@@ -232,7 +232,7 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
             get alchemy_json_api.pages_path
             expect(response.headers["Last-Modified"]).to be_nil
             expect(response.headers["ETag"]).to match(/W\/".+"/)
-            expect(response.headers["Cache-Control"]).to eq("max-age=10800, public, must-revalidate")
+            expect(response.headers["Cache-Control"]).to eq("max-age=600, public, must-revalidate")
           end
 
           it "returns a different etag if different filters are present" do
@@ -289,7 +289,7 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
 
             it "sets private cache headers" do
               get alchemy_json_api.pages_path
-              expect(response.headers["Cache-Control"]).to eq("max-age=10800, private, must-revalidate")
+              expect(response.headers["Cache-Control"]).to eq("max-age=600, private, must-revalidate")
             end
           end
 
@@ -389,7 +389,7 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
 
           first_etag = response.headers["Last-Modified"]
 
-          expect(response.headers["Cache-Control"]).to eq("max-age=10800, public, must-revalidate")
+          expect(response.headers["Cache-Control"]).to eq("max-age=600, public, must-revalidate")
 
           get alchemy_json_api.pages_path(filter: {page_layout_eq: "news"})
           expect(response.headers["Last-Modified"]).to eq(first_etag)

--- a/spec/requests/alchemy/json_api/pages_spec.rb
+++ b/spec/requests/alchemy/json_api/pages_spec.rb
@@ -50,6 +50,20 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
           expect(response.headers["Last-Modified"]).to eq(first_etag)
         end
 
+        it "can set cache duration via ENV variable" do
+          ENV["ALCHEMY_JSON_API_CACHE_DURATION"] = "60"
+          get alchemy_json_api.page_path(page)
+          expect(response.headers["Cache-Control"]).to eq("max-age=60, public, must-revalidate")
+          ENV["ALCHEMY_JSON_API_CACHE_DURATION"] = nil
+        end
+
+        it "can set stale-while-revalidate header via ENV variable" do
+          ENV["ALCHEMY_JSON_API_CACHE_STALE_WHILE_REVALIDATE"] = "60"
+          get alchemy_json_api.page_path(page)
+          expect(response.headers["Cache-Control"]).to eq("max-age=10800, public, stale-while-revalidate=60")
+          ENV["ALCHEMY_JSON_API_CACHE_STALE_WHILE_REVALIDATE"] = nil
+        end
+
         it "returns a different etag if different filters are present" do
           get alchemy_json_api.page_path(page)
           etag = response.headers["ETag"]


### PR DESCRIPTION
In order to get efficient CDN (Edge) caching for your json api we allow to set the `stale-while-revalidate` header to any integer value in seconds via the `ALCHEMY_JSON_API_CACHE_STALE_WHILE_REVALIDATE` env variable. 

Also lowering the default cache duration (`max-age`) from 3 hours (`10800`s) to 10 minutes (`600`s). Since the browser will first revalidate after this time passed we ensure that newly published content is available sooner (3 hours is a long time for your marketing team to wait for new content to be visible to your visitors). Since the server will always validate against
the etag we send as cache key it will return 304 (not modified) in most cases.