### PR TITLE
Use Ruby config to set caching options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,17 +65,33 @@ console.log(pages[0].name) // => Homepage
 
 Alchemy::JsonApi allows for caching API responses. It respects the caching configuration of your Rails app and of your Alchemy configuration and settings in the pages page layout configuration. Restricted pages are never cached.
 
-By default it sets the `max-age` `Cache-Control` header to 10 minutes (`600` seconds). You can change this by setting the `ALCHEMY_JSON_API_CACHE_DURATION` environment variable.
+By default it sets the `max-age` `Cache-Control` header to 10 minutes (`600` seconds). You can change this by configuring the `Alchemy::JsonApi.page_cache_max_age` setting. It is recommended to set this via an environment variable like this:
+
+```rb
+# config/initializers/alchemy_json_api.rb
+Alchemy::JsonApi.page_cache_max_age = ENV.fetch("ALCHEMY_JSON_API_CACHE_DURATION", 600).to_i
+```
 
 ### Edge Caching
 
-Alchemy sets the `must-revalidate` directive if caching is enabled. If your CDN supports it, you can change that to use the much more efficient `stale-while-revalidate` directive by setting the `ALCHEMY_JSON_API_STALE_WHILE_REVALIDATE` environment variable to any integer value.
+Alchemy sets the `must-revalidate` directive if caching is enabled. If your CDN supports it, you can change that to use the much more efficient `stale-while-revalidate` directive by changing the `Alchemy::JsonApi.page_caching_options` setting to any integer value.
+
+```rb
+# config/initializers/alchemy_json_api.rb
+Alchemy::JsonApi.page_caching_options = {
+  stale_while_revalidate: ENV.fetch("ALCHEMY_JSON_API_CACHE_STALE_WHILE_REVALIDATE", 60).to_i
+}
+```
+
+> [!TIP]
+> You can set any caching option that [`ActionController::ConditionalGet#expires_in` supports](https://api.rubyonrails.org/classes/ActionController/ConditionalGet.html#method-i-expires_in), like `stale_if_error`, `public` or `immutable`.
 
 ## Key transforms
 
 If you ever want to change how Alchemy serializes attributes you can set
 
 ```rb
+# config/initializers/alchemy_json_api.rb
 Alchemy::JsonApi.key_transform = :camel_lower
 ```
 

--- a/app/controllers/alchemy/json_api/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/pages_controller.rb
@@ -51,19 +51,11 @@ module Alchemy
       end
 
       def cache_duration
-        ENV.fetch("ALCHEMY_JSON_API_CACHE_DURATION", CACHE_DURATION).to_i
+        Alchemy::JsonApi.page_cache_max_age
       end
 
       def caching_options
-        if ENV["ALCHEMY_JSON_API_CACHE_STALE_WHILE_REVALIDATE"]
-          {
-            stale_while_revalidate: ENV["ALCHEMY_JSON_API_CACHE_STALE_WHILE_REVALIDATE"].to_i
-          }
-        else
-          {
-            must_revalidate: true
-          }
-        end
+        Alchemy::JsonApi.page_caching_options
       end
 
       # Get page w/o includes to get cache key

--- a/lib/alchemy/json_api.rb
+++ b/lib/alchemy/json_api.rb
@@ -6,6 +6,8 @@ require "alchemy/json_api/engine"
 
 module Alchemy
   module JsonApi
+    extend self
+
     # Set FastJsonapi key_transform
     #
     # Supported transformations:
@@ -14,15 +16,45 @@ module Alchemy
     # :camel_lower # "some_key" => "someKey"
     # :dash # "some_key" => "some-key"
     # :underscore # "some_key" => "some_key"
-    def self.key_transform=(value)
+    def key_transform=(value)
       @_key_transform = value
     end
 
     # FastJsonapi key_transform
     #
     # Default :underscore # "some_key" => "some_key"
-    def self.key_transform
+    def key_transform
       @_key_transform || :underscore
+    end
+
+    # HTTP Cache-Control max-age
+    #
+    # Can be set as `ALCHEMY_JSON_API_CACHE_DURATION` env var
+    #
+    # Default 600 (seconds)
+    def page_cache_max_age
+      @_page_cache_max_age ||= ENV.fetch("ALCHEMY_JSON_API_CACHE_DURATION", 600).to_i
+    end
+
+    def page_cache_max_age=(max_age)
+      @_page_cache_max_age = max_age
+    end
+
+    # HTTP Cache-Control options
+    #
+    # Set any of the ActionController::ConditionalGet#expires_in options
+    #
+    # See https://api.rubyonrails.org/classes/ActionController/ConditionalGet.html#method-i-expires_in
+    #
+    # Default `{must_revalidate: true}`
+    def page_caching_options
+      @_page_caching_options ||= {
+        must_revalidate: true
+      }
+    end
+
+    def page_caching_options=(options)
+      @_page_caching_options = options
     end
   end
 end

--- a/spec/requests/alchemy/json_api/pages_spec.rb
+++ b/spec/requests/alchemy/json_api/pages_spec.rb
@@ -50,18 +50,22 @@ RSpec.describe "Alchemy::JsonApi::Pages", type: :request do
           expect(response.headers["Last-Modified"]).to eq(first_etag)
         end
 
-        it "can set cache duration via ENV variable" do
-          ENV["ALCHEMY_JSON_API_CACHE_DURATION"] = "60"
+        it "can set cache duration via config" do
+          allow(Alchemy::JsonApi).to receive(:page_cache_max_age) { 60 }
           get alchemy_json_api.page_path(page)
           expect(response.headers["Cache-Control"]).to eq("max-age=60, public, must-revalidate")
-          ENV["ALCHEMY_JSON_API_CACHE_DURATION"] = nil
         end
 
-        it "can set stale-while-revalidate header via ENV variable" do
-          ENV["ALCHEMY_JSON_API_CACHE_STALE_WHILE_REVALIDATE"] = "60"
+        it "can set stale-while-revalidate header via config" do
+          allow(Alchemy::JsonApi).to receive(:page_caching_options) { {stale_while_revalidate: 60} }
           get alchemy_json_api.page_path(page)
           expect(response.headers["Cache-Control"]).to eq("max-age=600, public, stale-while-revalidate=60")
-          ENV["ALCHEMY_JSON_API_CACHE_STALE_WHILE_REVALIDATE"] = nil
+        end
+
+        it "can set stale_if_error header via config" do
+          allow(Alchemy::JsonApi).to receive(:page_caching_options) { {stale_if_error: 300} }
+          get alchemy_json_api.page_path(page)
+          expect(response.headers["Cache-Control"]).to eq("max-age=600, public, stale-if-error=300")
         end
 
         it "returns a different etag if different filters are present" do


### PR DESCRIPTION
Instead of ENV Vars we add support to set the caching options and `max-age` via the `Alchemy::JsonApi` Ruby API.

It falls back to the former ENV vars and we encourage to still use ENV vars to configure your API server, but you can just use Ruby integers if you like.

```rb
Alchemy::JsonApi.page_cache_max_age = ENV.fetch("ALCHEMY_JSON_API_CACHE_DURATION", 600).to_i
Alchemy::JsonApi.page_caching_options = {
  stale_while_revalidate: ENV.fetch("ALCHEMY_JSON_API_CACHE_STALE_WHILE_REVALIDATE", 60).to_i
}
```