### PR TITLE
feat: Store alchemy_preview_time in current global

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         alchemy_branch:
+          - 8.2-stable
           - main
         ruby:
-          - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
     env:
       ALCHEMY_BRANCH: ${{ matrix.alchemy_branch }}
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "sqlite3", "~> 2.2"
 
 alchemy_branch = ENV.fetch("ALCHEMY_BRANCH", "main")
 gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: alchemy_branch
-gem "alchemy-devise", github: "AlchemyCMS/alchemy-devise", branch: alchemy_branch
+gem "alchemy-devise", github: "AlchemyCMS/alchemy-devise", branch: "main"
 
 gem "rubocop", require: false
 gem "standard", "~> 1.25", require: false

--- a/app/controllers/alchemy/json_api/admin/pages_controller.rb
+++ b/app/controllers/alchemy/json_api/admin/pages_controller.rb
@@ -7,6 +7,9 @@ module Alchemy
         prepend_before_action { authorize! :edit_content, Alchemy::Page }
         before_action :set_current_preview, only: :show
 
+        include Alchemy::Admin::Timezone
+        include Alchemy::Admin::PreviewTime
+
         private
 
         def cache_duration

--- a/spec/controllers/alchemy/json_api/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/json_api/admin/pages_controller_spec.rb
@@ -19,5 +19,19 @@ RSpec.describe Alchemy::JsonApi::Admin::PagesController do
       get :show, params: {path: page.urlname}
       expect(Alchemy::Current.preview_page).to eq(page)
     end
+
+    context "with alchemy_preview_time param" do
+      it "stores preview time" do
+        preview_time = 1.day.from_now
+        get :show, params: {path: page.urlname, alchemy_preview_time: preview_time.iso8601}
+        expect(Alchemy::Current.preview_time).to be_within(1.second).of(preview_time)
+      end
+    end
+
+    it "runs action in given timezone" do
+      allow(Time).to receive(:use_zone).and_yield
+      get :show, params: {path: page.urlname, admin_timezone: "Hawaii"}
+      expect(Time).to have_received(:use_zone).with("Hawaii")
+    end
   end
 end


### PR DESCRIPTION
We need that to return content for given preview
time for the admin addition we made to alchemy.

~~**Needs https://github.com/AlchemyCMS/alchemy_cms/pull/3789**~~