### PR TITLE
feat: Cache ingredient serializers

### DIFF
--- a/lib/alchemy/json_api/ingredient_serializer.rb
+++ b/lib/alchemy/json_api/ingredient_serializer.rb
@@ -12,6 +12,7 @@ module Alchemy
         )
 
         klass.attribute :deprecated, &:deprecated?
+        klass.cache_options store: Rails.cache, namespace: "alchemy-jsonapi"
       end
     end
   end


### PR DESCRIPTION
We already cache pages and elements, but the pieces that
hold the actual content have not been cached yet.
