### PR TITLE
refactor: load elements through core's shared element repository

### DIFF
--- a/app/models/alchemy/json_api/page.rb
+++ b/app/models/alchemy/json_api/page.rb
@@ -45,7 +45,7 @@ module Alchemy
       def element_repository
         return Alchemy::ElementsRepository.none unless page_version
 
-        Alchemy::ElementsRepository.new(page_version.elements).visible
+        page_version.element_repository.visible
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

`Alchemy::JsonApi::Page` currently builds its element set by instantiating `Alchemy::ElementsRepository.new(page_version.elements)` directly. Core already exposes that same set through `Alchemy::PageVersion#element_repository`, so this reuses the shared seam instead of a parallel construction.

The motivation is upcoming performance work in alchemy_cms core. Core is introducing a shared element-loading path (repository memoization now, and a shared element preloader to eliminate the ingredient/tag N+1 later). By routing json_api through `page_version.element_repository`, this gem inherits those improvements automatically as they land in core, rather than having to mirror each change here.

The change is behaviour-preserving: `element_repository` still wraps the version's (eager-loaded) elements and applies the same `visible` filter, so serialization output and the controller's existing `includes` are unaffected.

## Checklist
- [x] I have followed the Pull Request guidelines
- [x] I have added a detailed description into the commit message
- [x] Existing tests cover this change (full suite green locally: 171 examples, 0 failures)