### PR TITLE
refactor: stop filtering deprecated content in the deserializer

### DIFF
--- a/dist/alchemy-json_api.js
+++ b/dist/alchemy-json_api.js
@@ -1,20 +1,14 @@
 import { deserialize as e } from "./deserialize.js";
 //#region src/alchemyApiDeserializer.js
-function t(e) {
-	let n = [];
-	return e.forEach((e) => {
-		e.nested_elements?.length > 0 && (e.nested_elements = t(e.nested_elements)), e.nestedElements?.length > 0 && (e.nestedElements = t(e.nestedElements)), e.essences?.length > 0 && (e.essences = e.essences.filter((e) => !e.deprecated)), e.deprecated || n.push(e);
-	}), n;
+var t = /* @__PURE__ */ new Set();
+function n(e) {
+	t.has(e) || (t.add(e), console.warn(`[@alchemy_cms/json_api] \`${e}\` is deprecated; use \`deserialize\` instead.`));
 }
-function n(n) {
-	let r = e(n);
-	return r.elements = t(r.elements), r;
+function r(t) {
+	return n("deserializePage"), e(t);
 }
-function r(n) {
-	let r = e(n);
-	return r.forEach((e) => {
-		e.elements = t(e.elements);
-	}), r;
+function i(t) {
+	return n("deserializePages"), e(t);
 }
 //#endregion
-export { e as deserialize, n as deserializePage, r as deserializePages };
+export { e as deserialize, r as deserializePage, i as deserializePages };

--- a/src/__tests__/alchemyApiDeserializer.spec.js
+++ b/src/__tests__/alchemyApiDeserializer.spec.js
@@ -1,7 +1,7 @@
 import { deserializePage, deserializePages } from "../alchemyApiDeserializer"
 
 describe("deserializePage", () => {
-  it("does not return any deprecated elements for single page", () => {
+  it("returns all elements, including deprecated ones and their nested elements", () => {
     const pageData = {
       data: {
         type: "page",
@@ -12,14 +12,8 @@ describe("deserializePage", () => {
         relationships: {
           elements: {
             data: [
-              {
-                type: "element",
-                id: "1"
-              },
-              {
-                type: "element",
-                id: "2"
-              }
+              { type: "element", id: "1" },
+              { type: "element", id: "2" }
             ]
           }
         }
@@ -33,28 +27,10 @@ describe("deserializePage", () => {
             deprecated: false
           },
           relationships: {
-            essences: {
-              data: [
-                {
-                  id: "1",
-                  type: "essence_text"
-                },
-                {
-                  id: "1",
-                  type: "essence_picture"
-                }
-              ]
-            },
             nested_elements: {
               data: [
-                {
-                  id: "3",
-                  type: "element"
-                },
-                {
-                  id: "4",
-                  type: "element"
-                }
+                { type: "element", id: "3" },
+                { type: "element", id: "4" }
               ]
             }
           }
@@ -85,178 +61,36 @@ describe("deserializePage", () => {
             deprecated: false
           },
           relationships: {}
-        },
-        {
-          type: "essence_text",
-          id: "1",
-          attributes: {
-            name: "text",
-            deprecated: true
-          }
-        },
-        {
-          type: "essence_picture",
-          id: "1",
-          attributes: {
-            name: "image",
-            deprecated: false
-          }
         }
       ]
     }
-    const page = deserializePage(pageData)
-    expect(page.elements).toEqual([
-      {
-        id: "1",
-        name: "article",
-        deprecated: false,
-        essences: [
-          {
-            id: "1",
-            name: "image",
-            deprecated: false
-          }
-        ],
-        nested_elements: [
-          {
-            id: "4",
-            name: "text",
-            deprecated: false
-          }
-        ]
-      }
-    ])
-  })
 
-  it("does not return any deprecated elements for single page with camelCased attributes", () => {
-    const pageData = {
-      data: {
-        type: "page",
-        id: "1",
-        attributes: {
-          name: "Homepage"
-        },
-        relationships: {
-          elements: {
-            data: [
-              {
-                type: "element",
-                id: "1"
-              },
-              {
-                type: "element",
-                id: "2"
-              }
-            ]
-          }
-        }
-      },
-      included: [
+    expect(deserializePage(pageData)).toEqual({
+      id: "1",
+      name: "Homepage",
+      elements: [
         {
-          type: "element",
           id: "1",
-          attributes: {
-            name: "article",
-            deprecated: false
-          },
-          relationships: {
-            essences: {
-              data: [
-                {
-                  id: "1",
-                  type: "essence_text"
-                },
-                {
-                  id: "1",
-                  type: "essence_picture"
-                }
-              ]
-            },
-            nestedElements: {
-              data: [
-                {
-                  id: "3",
-                  type: "element"
-                },
-                {
-                  id: "4",
-                  type: "element"
-                }
-              ]
-            }
-          }
+          name: "article",
+          deprecated: false,
+          nested_elements: [
+            { id: "3", name: "image", deprecated: true },
+            { id: "4", name: "text", deprecated: false }
+          ]
         },
         {
-          type: "element",
           id: "2",
-          attributes: {
-            name: "old",
-            deprecated: true
-          },
-          relationships: {}
-        },
-        {
-          type: "element",
-          id: "3",
-          attributes: {
-            name: "image",
-            deprecated: true
-          },
-          relationships: {}
-        },
-        {
-          type: "element",
-          id: "4",
-          attributes: {
-            name: "text",
-            deprecated: false
-          },
-          relationships: {}
-        },
-        {
-          type: "essence_text",
-          id: "1",
-          attributes: {
-            name: "text",
-            deprecated: true
-          }
-        },
-        {
-          type: "essence_picture",
-          id: "1",
-          attributes: {
-            name: "image",
-            deprecated: false
-          }
+          name: "old",
+          deprecated: true
         }
       ]
-    }
-    const page = deserializePage(pageData)
-    expect(page.elements).toEqual([
-      {
-        id: "1",
-        name: "article",
-        deprecated: false,
-        essences: [
-          {
-            id: "1",
-            name: "image",
-            deprecated: false
-          }
-        ],
-        nestedElements: [
-          {
-            id: "4",
-            name: "text",
-            deprecated: false
-          }
-        ]
-      }
-    ])
+    })
   })
+})
 
-  it("does not return any deprecated elements for pages", () => {
-    const pageData = {
+describe("deserializePages", () => {
+  it("returns all elements, including deprecated ones", () => {
+    const pagesData = {
       data: [
         {
           type: "page",
@@ -267,14 +101,8 @@ describe("deserializePage", () => {
           relationships: {
             elements: {
               data: [
-                {
-                  type: "element",
-                  id: "1"
-                },
-                {
-                  type: "element",
-                  id: "2"
-                }
+                { type: "element", id: "1" },
+                { type: "element", id: "2" }
               ]
             }
           }
@@ -288,32 +116,7 @@ describe("deserializePage", () => {
             name: "article",
             deprecated: false
           },
-          relationships: {
-            essences: {
-              data: [
-                {
-                  id: "1",
-                  type: "essence_text"
-                },
-                {
-                  id: "1",
-                  type: "essence_picture"
-                }
-              ]
-            },
-            nested_elements: {
-              data: [
-                {
-                  id: "3",
-                  type: "element"
-                },
-                {
-                  id: "4",
-                  type: "element"
-                }
-              ]
-            }
-          }
+          relationships: {}
         },
         {
           type: "element",
@@ -323,191 +126,17 @@ describe("deserializePage", () => {
             deprecated: true
           },
           relationships: {}
-        },
-        {
-          type: "element",
-          id: "3",
-          attributes: {
-            name: "image",
-            deprecated: true
-          },
-          relationships: {}
-        },
-        {
-          type: "element",
-          id: "4",
-          attributes: {
-            name: "text",
-            deprecated: false
-          },
-          relationships: {}
-        },
-        {
-          type: "essence_text",
-          id: "1",
-          attributes: {
-            name: "text",
-            deprecated: true
-          }
-        },
-        {
-          type: "essence_picture",
-          id: "1",
-          attributes: {
-            name: "image",
-            deprecated: false
-          }
         }
       ]
     }
-    const pages = deserializePages(pageData)
-    expect(pages[0].elements).toEqual([
-      {
-        id: "1",
-        name: "article",
-        deprecated: false,
-        essences: [
-          {
-            id: "1",
-            name: "image",
-            deprecated: false
-          }
-        ],
-        nested_elements: [
-          {
-            id: "4",
-            name: "text",
-            deprecated: false
-          }
-        ]
-      }
-    ])
-  })
 
-  it("does not return any deprecated elements for pages with camelCased attributes", () => {
-    const pageData = {
-      data: [
-        {
-          type: "page",
-          id: "1",
-          attributes: {
-            name: "Homepage"
-          },
-          relationships: {
-            elements: {
-              data: [
-                {
-                  type: "element",
-                  id: "1"
-                },
-                {
-                  type: "element",
-                  id: "2"
-                }
-              ]
-            }
-          }
-        }
-      ],
-      included: [
-        {
-          type: "element",
-          id: "1",
-          attributes: {
-            name: "article",
-            deprecated: false
-          },
-          relationships: {
-            essences: {
-              data: [
-                {
-                  id: "1",
-                  type: "essence_text"
-                },
-                {
-                  id: "1",
-                  type: "essence_picture"
-                }
-              ]
-            },
-            nestedElements: {
-              data: [
-                {
-                  id: "3",
-                  type: "element"
-                },
-                {
-                  id: "4",
-                  type: "element"
-                }
-              ]
-            }
-          }
-        },
-        {
-          type: "element",
-          id: "2",
-          attributes: {
-            name: "old",
-            deprecated: true
-          },
-          relationships: {}
-        },
-        {
-          type: "element",
-          id: "3",
-          attributes: {
-            name: "image",
-            deprecated: true
-          },
-          relationships: {}
-        },
-        {
-          type: "element",
-          id: "4",
-          attributes: {
-            name: "text",
-            deprecated: false
-          },
-          relationships: {}
-        },
-        {
-          type: "essence_text",
-          id: "1",
-          attributes: {
-            name: "text",
-            deprecated: true
-          }
-        },
-        {
-          type: "essence_picture",
-          id: "1",
-          attributes: {
-            name: "image",
-            deprecated: false
-          }
-        }
-      ]
-    }
-    const pages = deserializePages(pageData)
-    expect(pages[0].elements).toEqual([
+    expect(deserializePages(pagesData)).toEqual([
       {
         id: "1",
-        name: "article",
-        deprecated: false,
-        essences: [
-          {
-            id: "1",
-            name: "image",
-            deprecated: false
-          }
-        ],
-        nestedElements: [
-          {
-            id: "4",
-            name: "text",
-            deprecated: false
-          }
+        name: "Homepage",
+        elements: [
+          { id: "1", name: "article", deprecated: false },
+          { id: "2", name: "old", deprecated: true }
         ]
       }
     ])

--- a/src/alchemyApiDeserializer.js
+++ b/src/alchemyApiDeserializer.js
@@ -1,43 +1,36 @@
 import { deserialize } from "./deserialize"
 
-// Recursively filters all deprecated elements and essences from collection
-function filterDeprecatedElements(elements) {
-  const els = []
+const warned = new Set()
 
-  elements.forEach((element) => {
-    if (element.nested_elements?.length > 0) {
-      element.nested_elements = filterDeprecatedElements(
-        element.nested_elements
-      )
-    }
-    if (element.nestedElements?.length > 0) {
-      element.nestedElements = filterDeprecatedElements(element.nestedElements)
-    }
-    if (element.essences?.length > 0) {
-      element.essences = element.essences.filter((essence) => {
-        return !essence.deprecated
-      })
-    }
-    if (!element.deprecated) {
-      els.push(element)
-    }
-  })
-
-  return els
+// Warn once per function so callers notice the deprecation without spamming the
+// console on every call.
+function warnDeprecated(name) {
+  if (warned.has(name)) return
+  warned.add(name)
+  console.warn(
+    `[@alchemy_cms/json_api] \`${name}\` is deprecated; use \`deserialize\` instead.`
+  )
 }
 
-// Returns deserialized page without deprecated content
+/**
+ * Deserializes a JSON:API page document.
+ *
+ * @deprecated Use `deserialize` instead. `deserializePage` used to strip
+ * deprecated elements, but `deprecated` is an admin-only hint and must not
+ * alter the serialized output, so this is now only a thin wrapper around
+ * `deserialize`.
+ */
 export function deserializePage(pageData) {
-  const page = deserialize(pageData)
-  page.elements = filterDeprecatedElements(page.elements)
-  return page
+  warnDeprecated("deserializePage")
+  return deserialize(pageData)
 }
 
-// Returns deserialized pages without deprecated content
+/**
+ * Deserializes a collection of JSON:API page documents.
+ *
+ * @deprecated Use `deserialize` instead; see `deserializePage`.
+ */
 export function deserializePages(pagesData) {
-  const pages = deserialize(pagesData)
-  pages.forEach((page) => {
-    page.elements = filterDeprecatedElements(page.elements)
-  })
-  return pages
+  warnDeprecated("deserializePages")
+  return deserialize(pagesData)
 }


### PR DESCRIPTION
`deserializePage`/`deserializePages` stripped elements whose `deprecated` flag was set. But `deprecated` is an admin-only hint — it marks element/ingredient definitions that were removed from config so the CMS can warn editors. It should never remove content from a serialized page delivered to a frontend; doing so is destructive and opinionated.

It also turns out the filtering was already incomplete: `filterDeprecatedElements` handled elements and the pre-6.0 `essences`, but never the `ingredients` that replaced essences in Alchemy 6.0 — even though ingredients carry the same `deprecated` flag. So ingredient deprecation has been silently unfiltered in production for years with no ill effect, which is good evidence the filtering isn't needed.

This removes `filterDeprecatedElements` entirely. `deserializePage`/`deserializePages` remain as thin, API-compatible wrappers around `deserialize` and no longer mutate the output; the specs now assert that deprecated elements and nested elements are preserved.

Stacked on #200 (merged); base is `main`.